### PR TITLE
Escape Parameters

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -65,7 +65,10 @@ func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedVa
 	}
 
 	tmpl := template(q)
-	stmt := statement(tmpl, args)
+	stmt, err := statement(tmpl, args)
+	if err != nil {
+		return nil, err
+	}
 	return query(ctx, session, stmt)
 }
 
@@ -77,7 +80,10 @@ func (c *Conn) ExecContext(ctx context.Context, q string, args []driver.NamedVal
 	}
 
 	tmpl := template(q)
-	stmt := statement(tmpl, args)
+	stmt, err := statement(tmpl, args)
+	if err != nil {
+		return nil, err
+	}
 	return exec(ctx, session, stmt)
 }
 

--- a/escaper.go
+++ b/escaper.go
@@ -22,7 +22,7 @@ func EscapeArg(arg driver.NamedValue) (string, error) {
 	case string:
 		return fmt.Sprintf("'%v'", strings.ReplaceAll(v, "'", "''")), nil
 	case time.Time:
-		return v.Format(KTimeFmt), nil
+		return "'" + v.Format(KTimeFmt) + "'", nil
 	default:
 		return "", fmt.Errorf("unsupported parameter type %T for value %v", v, v)
 	}

--- a/escaper.go
+++ b/escaper.go
@@ -1,0 +1,29 @@
+package dbsql
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	KTimeFmt = "2006-01-02T15:04:05.999-07:00"
+)
+
+func EscapeArg(arg driver.NamedValue) (string, error) {
+	switch v := arg.Value.(type) {
+	case int64:
+		return fmt.Sprintf("%v", v), nil
+	case float64:
+		return fmt.Sprintf("%v", v), nil
+	case bool:
+		return fmt.Sprintf("%v", v), nil
+	case string:
+		return fmt.Sprintf("'%v'", strings.ReplaceAll(v, "'", "''")), nil
+	case time.Time:
+		return v.Format(KTimeFmt), nil
+	default:
+		return "", fmt.Errorf("unsupported parameter type %T for value %v", v, v)
+	}
+}

--- a/escaper.go
+++ b/escaper.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	KTimeFmt = "2006-01-02T15:04:05.999-07:00"
+	TimeFmt = "2006-01-02T15:04:05.999-07:00"
 )
 
 func EscapeArg(arg driver.NamedValue) (string, error) {
@@ -22,7 +22,7 @@ func EscapeArg(arg driver.NamedValue) (string, error) {
 	case string:
 		return fmt.Sprintf("'%v'", strings.ReplaceAll(v, "'", "''")), nil
 	case time.Time:
-		return "'" + v.Format(KTimeFmt) + "'", nil
+		return "'" + v.Format(TimeFmt) + "'", nil
 	default:
 		return "", fmt.Errorf("unsupported parameter type %T for value %v", v, v)
 	}

--- a/escaper_test.go
+++ b/escaper_test.go
@@ -15,7 +15,7 @@ func TestEscaper(t *testing.T) {
 		{Value: int64(1024), ExpectedOutput: `1024`},
 		{Value: float64(1024.5), ExpectedOutput: `1024.5`},
 		{Value: true, ExpectedOutput: "true"},
-		{Value: time.Date(2020, time.April, 11, 21, 34, 01, 0, time.UTC), ExpectedOutput: "2020-04-11T21:34:01+00:00"},
+		{Value: time.Date(2020, time.April, 11, 21, 34, 01, 0, time.UTC), ExpectedOutput: "'2020-04-11T21:34:01+00:00'"},
 	}
 
 	for _, test := range testcases {

--- a/escaper_test.go
+++ b/escaper_test.go
@@ -1,0 +1,31 @@
+package dbsql
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+)
+
+func TestEscaper(t *testing.T) {
+	testcases := []struct {
+		Value          driver.Value
+		ExpectedOutput string
+	}{
+		{Value: "a'b'c", ExpectedOutput: `'a''b''c'`},
+		{Value: int64(1024), ExpectedOutput: `1024`},
+		{Value: float64(1024.5), ExpectedOutput: `1024.5`},
+		{Value: true, ExpectedOutput: "true"},
+		{Value: time.Date(2020, time.April, 11, 21, 34, 01, 0, time.UTC), ExpectedOutput: "2020-04-11T21:34:01+00:00"},
+	}
+
+	for _, test := range testcases {
+		actual, err := EscapeArg(driver.NamedValue{Value: test.Value})
+		if err != nil {
+			t.Error(err)
+		}
+		if actual != test.ExpectedOutput {
+			t.Errorf("expecting %v, actual value: %v", test.ExpectedOutput, actual)
+		}
+
+	}
+}

--- a/statement_test.go
+++ b/statement_test.go
@@ -16,7 +16,7 @@ func TestStatement(t *testing.T) {
 			args: []driver.NamedValue{
 				{Ordinal: 1, Value: "val_1"},
 			},
-			target: "val_1 p1",
+			target: "'val_1' p1",
 		},
 		{
 			stmt: "@p1 @p10 @p11 @named @named1 @p1",
@@ -25,7 +25,7 @@ func TestStatement(t *testing.T) {
 				{Ordinal: 10, Name: "named", Value: "val_named"},
 				{Ordinal: 11, Value: "val_11"},
 			},
-			target: "val_1 @p10 val_11 val_named @named1 val_1",
+			target: "'val_1' @p10 'val_11' 'val_named' @named1 'val_1'",
 		},
 	}
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -30,7 +30,10 @@ func TestStatement(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := statement(tt.stmt, tt.args)
+		result, err := statement(tt.stmt, tt.args)
+		if err != nil {
+			t.Error(err)
+		}
 
 		if result != tt.target {
 			t.Fatalf("mismatch for statement: %q\n\ttarget: %q\n\tresult: %q", tt.stmt, tt.target, result)


### PR DESCRIPTION
In the current implementation, the query
```sql
SELECT *
FROM table_name
WHERE string_column = ?;
```
with arg list `[]any{"a'b'c"}` will be translated into the following invalid query string:
```sql
SELECT *
FROM table_name
WHERE string_column = a'b'c;
```

This PR escapes string, time and turn the query into:
```sql
SELECT *
FROM table_name
WHERE string_column = 'a''b''c';
```



Referring to how python connector escape strings:
https://github.com/databricks/databricks-sql-connector/blob/a7af04c8a0df274b443fcc5ca6b40457019ab5ce/src/databricks/sql/utils.py#L126