### PR TITLE
Fix: FetchResults truncates rows returned by the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 0.1.4 (2022-07-30)
 
 - Fix: Could not fetch rowsets greater than the value of `maxRows` (#18)
+- Updated default user agent
+- Updated README and CONTRIBUTING
 
 ## 0.1.3 (2022-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.x (Unreleased)
 
+## 0.1.4 (2022-07-30)
+
+- Fix: Could not fetch rowsets greater than the value of `maxRows` (#18)
 
 ## 0.1.3 (2022-06-16)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The DSN format is:
 databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]
 ```
 
-You can set HTTP Timeout value by appending a `timeout` query parameter (in milliseconds) and you can set max rows to retrieve by setting the `maxRows` query parameter:
+You can set HTTP Timeout value by appending a `timeout` query parameter (in milliseconds) and you can set max rows to retrieve per network request by setting the `maxRows` query parameter:
 
 ```
 databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]?timeout=1000&maxRows=1000


### PR DESCRIPTION
## Description

Apache Hive thrift always sends `HasMoreResults==false` even when more results are available. This change updates the Next() method to continue fetching pages of results until an empty page is received.

This quirk of behaviour also affects the [Databricks NodeJS connector](https://github.com/databricks/databricks-sql-nodejs/issues/21) and we work around it in a similar way there.


