### PR TITLE
[PECO-270] allow clients to provide client info in user agent

### DIFF
--- a/databricks.go
+++ b/databricks.go
@@ -12,13 +12,13 @@ func init() {
 
 // Options for driver connection
 type Options struct {
-	Host     string
-	Port     string
-	Token    string
-	HTTPPath string
-	ClientId string
-	MaxRows  int64
-	Timeout  int
+	Host           string
+	Port           string
+	Token          string
+	HTTPPath       string
+	MaxRows        int64
+	Timeout        int
+	UserAgentEntry string
 
 	LogOut io.Writer
 }

--- a/databricks.go
+++ b/databricks.go
@@ -16,6 +16,8 @@ type Options struct {
 	Port     string
 	Token    string
 	HTTPPath string
+	ClientId string
+	Version  string
 	MaxRows  int64
 	Timeout  int
 
@@ -24,5 +26,5 @@ type Options struct {
 
 var (
 	// DefaultOptions for the driver
-	DefaultOptions = Options{Port: "443", MaxRows: 10000, LogOut: ioutil.Discard}
+	DefaultOptions = Options{Port: "443", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 10000, LogOut: ioutil.Discard}
 )

--- a/databricks.go
+++ b/databricks.go
@@ -17,14 +17,19 @@ type Options struct {
 	Token    string
 	HTTPPath string
 	ClientId string
-	Version  string
 	MaxRows  int64
 	Timeout  int
 
 	LogOut io.Writer
 }
 
+const (
+	// Constants for Go driver
+	DriverName    = "godatabrickssqlconnector"
+	DriverVersion = "0.9.0"
+)
+
 var (
 	// DefaultOptions for the driver
-	DefaultOptions = Options{Port: "443", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 10000, LogOut: ioutil.Discard}
+	DefaultOptions = Options{Port: "443", MaxRows: 10000, LogOut: ioutil.Discard}
 )

--- a/driver.go
+++ b/driver.go
@@ -101,6 +101,12 @@ func parseURI(uri string) (*Options, error) {
 		}
 	}
 
+	clientId, ok := query["clientId"]
+
+	if ok {
+		opts.ClientId = clientId[0]
+	}
+
 	return &opts, nil
 }
 
@@ -159,8 +165,8 @@ func connect(opts *Options) (*Conn, error) {
 
 	httpTransport, ok := transport.(*thrift.THttpClient)
 	if ok {
-		// TODO: currently masking as a python connector until additional user agents are white listed.
-		httpTransport.SetHeader("User-Agent", "godatabrickssqlconnector/0.9.0 (go-dbsql)")
+		userAgent := fmt.Sprintf("godatabrickssqlconnector/%s (%s)", opts.Version, opts.ClientId)
+		httpTransport.SetHeader("User-Agent", userAgent)
 	}
 
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,27 +12,27 @@ func TestParseURI(t *testing.T) {
 	}{
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
 		},
 		{
-			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&clientId=client-provided-info",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "client-provided-info", Version: "0.9.0", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&userAgentEntry=client-provided-info",
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", UserAgentEntry: "client-provided-info", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 	}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,23 +12,27 @@ func TestParseURI(t *testing.T) {
 	}{
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+		},
+		{
+			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&clientId=client-provided-info",
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "client-provided-info", Version: "0.9.0", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", ClientId: "go-dbsql", Version: "0.9.0", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
 		},
 	}
 


### PR DESCRIPTION
Provide clients a way to override the `clientId` (user-agent suffix) and `godatabrickssqlconnector` version in the user agent

### E2E Test
Ran `list.go` example on IDE with `DATABRICKS_DSN=databricks://:dapie80c33546da149a3ea2876f35b32e644@e2-demo-west.cloud.databricks.com/sql/1.0/endpoints/77d7dabbececf7ca?clientId=go-dbsql` env var:
```
GOROOT=/opt/homebrew/Cellar/go/1.19/libexec #gosetup
GOPATH=/Users/matthew.kim/go #gosetup
/opt/homebrew/Cellar/go/1.19/libexec/bin/go build -o /private/var/folders/01/yq3bj65n38x_t6q8wbdc0xj00000gp/T/GoLand/___go_build_github_com_databricks_databricks_sql_go_examples_list github.com/databricks/databricks-sql-go/examples/list #gosetup
/private/var/folders/01/yq3bj65n38x_t6q8wbdc0xj00000gp/T/GoLand/___go_build_github_com_databricks_databricks_sql_go_examples_list
**userAgent:  godatabrickssqlconnector/0.9.0 (go1.19; darwin; go-dbsql)**
2022/09/13 12:53:03 Databases:
2022/09/13 12:53:03 0. 000_demo_db
2022/09/13 12:53:03 1. 20210712_demo_takaakiyayoi
...
```

Ran `list.go` example on IDE with `DATABRICKS_DSN=databricks://:dapie80c33546da149a3ea2876f35b32e644@e2-demo-west.cloud.databricks.com/sql/1.0/endpoints/77d7dabbececf7ca` env var:
```
GOROOT=/opt/homebrew/Cellar/go/1.19/libexec #gosetup
GOPATH=/Users/matthew.kim/go #gosetup
/opt/homebrew/Cellar/go/1.19/libexec/bin/go build -o /private/var/folders/01/yq3bj65n38x_t6q8wbdc0xj00000gp/T/GoLand/___go_build_github_com_databricks_databricks_sql_go_examples_list github.com/databricks/databricks-sql-go/examples/list #gosetup
/private/var/folders/01/yq3bj65n38x_t6q8wbdc0xj00000gp/T/GoLand/___go_build_github_com_databricks_databricks_sql_go_examples_list
**userAgent:  godatabrickssqlconnector/0.9.0 (go1.19; darwin)**
2022/09/13 12:53:03 Databases:
2022/09/13 12:53:03 0. 000_demo_db
2022/09/13 12:53:03 1. 20210712_demo_takaakiyayoi
...
```
