### PR TITLE
[PECO-306] bug fix for escape characters breaking E2E examples

### DIFF
--- a/escaper.go
+++ b/escaper.go
@@ -20,7 +20,7 @@ func EscapeArg(arg driver.NamedValue) (string, error) {
 	case bool:
 		return fmt.Sprintf("%v", v), nil
 	case string:
-		return fmt.Sprintf("'%v'", strings.ReplaceAll(v, "'", "''")), nil
+		return fmt.Sprintf("%v", strings.ReplaceAll(v, "'", "''")), nil
 	case time.Time:
 		return "'" + v.Format(TimeFmt) + "'", nil
 	default:

--- a/escaper_test.go
+++ b/escaper_test.go
@@ -11,7 +11,7 @@ func TestEscaper(t *testing.T) {
 		Value          driver.Value
 		ExpectedOutput string
 	}{
-		{Value: "a'b'c", ExpectedOutput: `'a''b''c'`},
+		{Value: "a'b'c", ExpectedOutput: `a''b''c`},
 		{Value: int64(1024), ExpectedOutput: `1024`},
 		{Value: float64(1024.5), ExpectedOutput: `1024.5`},
 		{Value: true, ExpectedOutput: "true"},

--- a/statement.go
+++ b/statement.go
@@ -107,11 +107,10 @@ func statement(tmpl string, args []driver.NamedValue) (string, error) {
 		} else {
 			re = regexp.MustCompile(fmt.Sprintf("@p%d%s", arg.Ordinal, `\b`))
 		}
-		escaped, err := EscapeArg(arg)
+		val, err := EscapeArg(arg)
 		if err != nil {
 			return "", err
 		}
-		val := fmt.Sprintf("%v", escaped)
 		stmt = re.ReplaceAllString(stmt, val)
 	}
 	return stmt, nil

--- a/statement_test.go
+++ b/statement_test.go
@@ -16,7 +16,7 @@ func TestStatement(t *testing.T) {
 			args: []driver.NamedValue{
 				{Ordinal: 1, Value: "val_1"},
 			},
-			target: "'val_1' p1",
+			target: "val_1 p1",
 		},
 		{
 			stmt: "@p1 @p10 @p11 @named @named1 @p1",
@@ -25,7 +25,7 @@ func TestStatement(t *testing.T) {
 				{Ordinal: 10, Name: "named", Value: "val_named"},
 				{Ordinal: 11, Value: "val_11"},
 			},
-			target: "'val_1' @p10 'val_11' 'val_named' @named1 'val_1'",
+			target: "val_1 @p10 val_11 val_named @named1 val_1",
 		},
 	}
 


### PR DESCRIPTION
Since release v0.1.3, When running `examples/list/list.go`, the `SHOW TABLES IN @p1` queries were all failing with messages like these:
```
2022/09/09 19:16:14 error in querying database 000_demo_db: Error running query: [PARSE_SYNTAX_ERROR] org.apache.spark.sql.catalyst.parser.ParseException: 
[PARSE_SYNTAX_ERROR] Syntax error at or near ''000_demo_db''(line 1, pos 15)

== SQL ==
SHOW TABLES IN '000_demo_db'
---------------^^^
```

After this change, these examples work as it had before release v0.1.3:
```
2022/09/09 19:18:58 Tables in 000_demo_db:
2022/09/09 19:18:58   bi0_mbpartner
```

Signed-off-by: Matthew Kim <11141331+mattdeekay@users.noreply.github.com>