### PR TITLE
[PECO-271] Support cancel operation

### DIFF
--- a/hive/operation.go
+++ b/hive/operation.go
@@ -119,8 +119,8 @@ func (op *Operation) Close(ctx context.Context) error {
 	return nil
 }
 
-// Cancel cancels operation
-func (op *Operation) Cancel(ctx context.Context) error {
+// private method to cancel operation
+func (op *Operation) cancel(ctx context.Context) error {
 	req := cli_service.TCancelOperationReq{
 		OperationHandle: op.h,
 	}

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -118,3 +118,21 @@ func (op *Operation) Close(ctx context.Context) error {
 	op.hive.log.Printf("close operation: %v", guid(op.h.OperationId.GUID))
 	return nil
 }
+
+// Cancel cancels operation
+func (op *Operation) Cancel(ctx context.Context) error {
+	req := cli_service.TCancelOperationReq{
+		OperationHandle: op.h,
+	}
+
+	resp, err := op.hive.client.CancelOperation(ctx, &req)
+	if err != nil {
+		return err
+	}
+	if err := checkStatus(resp); err != nil {
+		return err
+	}
+
+	op.hive.log.Printf("cancel operation: %v", guid(op.h.OperationId.GUID))
+	return nil
+}


### PR DESCRIPTION
### Description
Supports cancel operation (e.g. for long-running queries)

### Testing
#### Testing with synchronous query execution
Modified `statement.go: 149 (func exec)` to Cancel instead of Close and tested via IDE
![Screen Shot 2022-09-21 at 11 37 12 AM](https://user-images.githubusercontent.com/11141331/191584260-4bb96174-6385-46f6-92cf-8a8fabb8abd7.png)


#### Testing with asynchronous query execution
When manually overriding `session.ExecuteStatement` to RunAsync: true in code and running the above query, able to confirm that cancel operation work as intended and cancels the query execution.
![Screen Shot 2022-09-21 at 1 11 27 PM](https://user-images.githubusercontent.com/11141331/191601069-6ddaea6b-8b3a-4925-97b6-61b27f4d3032.png)

#### (Earlier Caveat - no longer applies)
`session.ExecuteStatement` (`s.hive.client.ExecuteStatement`) appears to work synchronously because the SDK will not return a response until the query is fully executed. I was unable to test cancellation while query was executing, only the cancellation before FetchResults

