### PR TITLE
Support asynchronous queries

### DIFF
--- a/databricks.go
+++ b/databricks.go
@@ -19,6 +19,7 @@ type Options struct {
 	MaxRows        int64
 	Timeout        int
 	UserAgentEntry string
+	RunAsync       bool
 
 	LogOut io.Writer
 }
@@ -31,5 +32,5 @@ const (
 
 var (
 	// DefaultOptions for the driver
-	DefaultOptions = Options{Port: "443", MaxRows: 10000, LogOut: ioutil.Discard}
+	DefaultOptions = Options{Port: "443", MaxRows: 10000, RunAsync: true, LogOut: ioutil.Discard}
 )

--- a/driver.go
+++ b/driver.go
@@ -107,6 +107,16 @@ func parseURI(uri string) (*Options, error) {
 		opts.UserAgentEntry = userAgentEntry[0]
 	}
 
+	runAsync, ok := query["runAsync"]
+
+	if ok {
+		boolValue, err := strconv.ParseBool(runAsync[0])
+		if err != nil {
+			return nil, fmt.Errorf("runAsync value wrongly formatted: %w", err)
+		}
+		opts.RunAsync = boolValue
+	}
+
 	return &opts, nil
 }
 
@@ -177,7 +187,7 @@ func connect(opts *Options) (*Conn, error) {
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 	tclient := thrift.NewTStandardClient(protocolFactory.GetProtocol(transport), protocolFactory.GetProtocol(transport))
 
-	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows})
+	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows, RunAsync: opts.RunAsync})
 
 	return &Conn{client: client, t: transport, log: logger}, nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,27 +12,27 @@ func TestParseURI(t *testing.T) {
 	}{
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, RunAsync: true, Timeout: 0, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, RunAsync: true, MaxRows: 10000, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, RunAsync: true, MaxRows: 1000, LogOut: ioutil.Discard},
 		},
 		{
-			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&userAgentEntry=client-provided-info",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", UserAgentEntry: "client-provided-info", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&userAgentEntry=client-provided-info&runAsync=false",
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", UserAgentEntry: "client-provided-info", Timeout: 123, MaxRows: 1000, RunAsync: false, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, RunAsync: true, LogOut: ioutil.Discard},
 		},
 		{
 			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, RunAsync: true, LogOut: ioutil.Discard},
 		},
 	}
 

--- a/examples/random/random.go
+++ b/examples/random/random.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	_ "github.com/databricks/databricks-sql-go"
+	"log"
+	"os"
+)
+
+func main() {
+	dsn := os.Getenv("DATABRICKS_DSN")
+	//dsn := "databricks://:dapibad4be4021a53249cda07bd152cd715a@e2-dogfood.staging.cloud.databricks.com/sql/1.0/endpoints/e5edb16633f87f9b?runAsync=false"
+	if dsn == "" {
+		log.Fatalf("Please provide a connection string by setting the DATABRICKS_DSN environment variable.")
+	}
+
+	db, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatalf("Could not connect to %s: %s", dsn, err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	rows, err := db.QueryContext(ctx, "SELECT id FROM RANGE(1000000) ORDER BY RANDOM() + 2 asc")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var id string
+
+	ids := make([]string, 0)
+
+	for rows.Next() {
+		if err := rows.Scan(&id); err != nil {
+			log.Println("Error getting id")
+			log.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Ids:")
+
+	for i, id := range ids {
+		log.Printf("%d. %s", i, id)
+	}
+}

--- a/hive/client.go
+++ b/hive/client.go
@@ -17,7 +17,8 @@ type Client struct {
 
 // Options for Hive Client
 type Options struct {
-	MaxRows int64
+	MaxRows  int64
+	RunAsync bool
 }
 
 // NewClient creates Hive Client

--- a/hive/session.go
+++ b/hive/session.go
@@ -36,6 +36,7 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt string) (*Operation
 	req := cli_service.TExecuteStatementReq{
 		SessionHandle: s.h,
 		Statement:     stmt,
+		RunAsync:      s.hive.opts.RunAsync,
 	}
 	resp, err := s.hive.client.ExecuteStatement(ctx, &req)
 


### PR DESCRIPTION
### Description
Support asynchronous queries and set async = True as default.

### Approach

- Add RunAsync as an option to URI (e.g. `DATABRICKS_DSN=databricks://:dapibad4be4021a53249cda07bd152cd715a@e2-dogfood.staging.cloud.databricks.com/sql/1.0/endpoints/e5edb16633f87f9b?runAsync=true`