### PR TITLE
implementing ping, close. Add namespace support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	ts "github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
@@ -17,7 +17,7 @@ import (
 type conn struct {
 	cfg     *config.Config
 	client  *client.ThriftServiceClient
-	session *cli_service.TOpenSessionResp
+	session *ts.TOpenSessionResp
 }
 
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
@@ -29,7 +29,12 @@ func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 }
 
 func (c *conn) Close() error {
-	return ErrNotImplemented
+	_, err := c.client.CloseSession(context.Background(), &ts.TCloseSessionReq{
+		SessionHandle: c.session.SessionHandle,
+	})
+
+	return err
+
 }
 
 func (c *conn) Begin() (driver.Tx, error) {
@@ -41,19 +46,26 @@ func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 }
 
 func (c *conn) Ping(ctx context.Context) error {
-	return ErrNotImplemented
+	_, err := c.executeStatement(ctx, "select 1", nil)
+	if err != nil {
+		log.Err(err).Msg("ping error")
+		return driver.ErrBadConn
+	}
+	return nil
 }
 
+// Implementation of SessionResetter
 func (c *conn) ResetSession(ctx context.Context) error {
-	return ErrNotImplemented
+	// For now our session does not have any important state to reset before re-use
+	return nil
 }
 
 func (c *conn) IsValid() bool {
-	return true
+	return c.session.GetStatus().StatusCode == ts.TStatusCode_SUCCESS_STATUS
 }
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	req := cli_service.TExecuteStatementReq{
+	req := ts.TExecuteStatementReq{
 		SessionHandle: c.session.SessionHandle,
 		Statement:     query,
 		QueryTimeout:  int64(c.cfg.TimeoutSeconds),
@@ -85,7 +97,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		switch opStatus.GetOperationState() {
 		// terminal states
 		// good
-		case cli_service.TOperationState_FINISHED_STATE:
+		case ts.TOperationState_FINISHED_STATE:
 			// return results
 			rows := rows{
 				client:               c.client,
@@ -96,14 +108,14 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 			}
 			return &rows, nil
 		// bad
-		case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
+		case ts.TOperationState_CANCELED_STATE, ts.TOperationState_CLOSED_STATE, ts.TOperationState_ERROR_STATE, ts.TOperationState_TIMEDOUT_STATE:
 			// do we need to close the operation in these cases?
 			log.Info().Msgf("bad state: %s", opStatus.GetOperationState())
 			log.Info().Msg(opStatus.GetErrorMessage())
 
 			return nil, fmt.Errorf(opStatus.GetErrorMessage())
 		// live states
-		case cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE, cli_service.TOperationState_RUNNING_STATE:
+		case ts.TOperationState_INITIALIZED_STATE, ts.TOperationState_PENDING_STATE, ts.TOperationState_RUNNING_STATE:
 			statusResp, err := c.pollOperation(ctx, opHandle)
 			if err != nil {
 				return nil, err
@@ -111,7 +123,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 			switch statusResp.GetOperationState() {
 			// terminal states
 			// good
-			case cli_service.TOperationState_FINISHED_STATE:
+			case ts.TOperationState_FINISHED_STATE:
 				// return handle to fetch results later
 				rows := rows{
 					client:   c.client,
@@ -120,7 +132,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 				}
 				return &rows, nil
 			// bad
-			case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
+			case ts.TOperationState_CANCELED_STATE, ts.TOperationState_CLOSED_STATE, ts.TOperationState_ERROR_STATE, ts.TOperationState_TIMEDOUT_STATE:
 				log.Info().Msgf("bad state: %s", statusResp.GetOperationState())
 				log.Info().Msg(statusResp.GetErrorMessage())
 				return nil, fmt.Errorf(statusResp.GetErrorMessage())
@@ -145,7 +157,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		switch statusResp.GetOperationState() {
 		// terminal states
 		// good
-		case cli_service.TOperationState_FINISHED_STATE:
+		case ts.TOperationState_FINISHED_STATE:
 			// return handle to fetch results later
 			rows := rows{
 				client:   c.client,
@@ -154,7 +166,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 			}
 			return &rows, nil
 		// bad
-		case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
+		case ts.TOperationState_CANCELED_STATE, ts.TOperationState_CLOSED_STATE, ts.TOperationState_ERROR_STATE, ts.TOperationState_TIMEDOUT_STATE:
 			log.Info().Msgf("bad state: %s", statusResp.GetOperationState())
 			log.Info().Msg(statusResp.GetErrorMessage())
 			return nil, fmt.Errorf(statusResp.GetErrorMessage())
@@ -167,16 +179,16 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	}
 }
 
-func (c *conn) executeStatement(ctx context.Context, query string, args []driver.NamedValue) (*cli_service.TExecuteStatementResp, error) {
+func (c *conn) executeStatement(ctx context.Context, query string, args []driver.NamedValue) (*ts.TExecuteStatementResp, error) {
 	sentinel := sentinel.Sentinel{
 		OnDoneFn: func(statusResp any) (any, error) {
-			req := cli_service.TExecuteStatementReq{
+			req := ts.TExecuteStatementReq{
 				SessionHandle: c.session.SessionHandle,
 				Statement:     query,
 				RunAsync:      c.cfg.RunAsync,
 				QueryTimeout:  int64(c.cfg.TimeoutSeconds),
 				// this is specific for databricks. It shortcuts server roundtrips
-				GetDirectResults: &cli_service.TSparkGetDirectResults{
+				GetDirectResults: &ts.TSparkGetDirectResults{
 					MaxRows: int64(c.cfg.MaxRows),
 				},
 				// CanReadArrowResult_: &t,
@@ -191,28 +203,28 @@ func (c *conn) executeStatement(ctx context.Context, query string, args []driver
 	if err != nil {
 		return nil, err
 	}
-	exStmtResp, ok := res.(*cli_service.TExecuteStatementResp)
+	exStmtResp, ok := res.(*ts.TExecuteStatementResp)
 	if !ok {
 		return nil, fmt.Errorf("databricks: invalid execute statement response")
 	}
 	return exStmtResp, err
 }
 
-func (c *conn) pollOperation(ctx context.Context, opHandle *cli_service.TOperationHandle) (*cli_service.TGetOperationStatusResp, error) {
-	var statusResp *cli_service.TGetOperationStatusResp
+func (c *conn) pollOperation(ctx context.Context, opHandle *ts.TOperationHandle) (*ts.TGetOperationStatusResp, error) {
+	var statusResp *ts.TGetOperationStatusResp
 	pollSentinel := sentinel.Sentinel{
 		OnDoneFn: func(statusResp any) (any, error) {
 			return statusResp, nil
 		},
 		StatusFn: func() (sentinel.Done, any, error) {
 			var err error
-			statusResp, err = c.client.GetOperationStatus(ctx, &cli_service.TGetOperationStatusReq{
+			statusResp, err = c.client.GetOperationStatus(ctx, &ts.TGetOperationStatusReq{
 				OperationHandle: opHandle,
 			})
 			return func() bool {
 				// which other states?
 				switch statusResp.GetOperationState() {
-				case cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE, cli_service.TOperationState_RUNNING_STATE:
+				case ts.TOperationState_INITIALIZED_STATE, ts.TOperationState_PENDING_STATE, ts.TOperationState_RUNNING_STATE:
 					return false
 				default:
 					return true
@@ -220,19 +232,18 @@ func (c *conn) pollOperation(ctx context.Context, opHandle *cli_service.TOperati
 			}, statusResp, err
 		},
 		OnCancelFn: func() (any, error) {
-			ret, err := c.client.CancelOperation(context.Background(), &cli_service.TCancelOperationReq{
+			ret, err := c.client.CancelOperation(context.Background(), &ts.TCancelOperationReq{
 				OperationHandle: opHandle,
 			})
 			return ret, err
 		},
 	}
 	_, resp, err := pollSentinel.Watch(ctx, 100*time.Millisecond, 0)
-	statusResp, ok := resp.(*cli_service.TGetOperationStatusResp)
+	statusResp, ok := resp.(*ts.TGetOperationStatusResp)
 	if !ok {
 		return nil, fmt.Errorf("could not read operation status")
 	}
 	return statusResp, err
-
 }
 
 var _ driver.Conn = (*conn)(nil)

--- a/driver_e2e_test.go
+++ b/driver_e2e_test.go
@@ -192,7 +192,6 @@ func TestQueryContextDirectResultsError(t *testing.T) {
 
 	// rows.Close()
 }
-
 func strPtr(s string) *string {
 	return &s
 }

--- a/examples/queryrows/main.go
+++ b/examples/queryrows/main.go
@@ -42,6 +42,10 @@ func main() {
 	// ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	// defer cancel()
 	ctx := context.Background()
+	if err := db.Ping(); err != nil {
+		fmt.Println(err)
+	}
+
 	rows, err1 := db.QueryContext(ctx, `select cut from default.diamonds`)
 	if err1 != nil {
 		if err1 == sql.ErrNoRows {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,8 @@ import (
 type Config struct {
 	Host          string // from databricks UI
 	Port          int    // from databricks UI
-	Catalog       string //??
-	Database      string
+	Catalog       *string
+	Schema        *string
 	AccessToken   string      // from databricks UI
 	TLSConfig     *tls.Config // nil disables TLS. Is it needed?
 	Protocol      string      // defaults to https. From databricks UI
@@ -36,11 +36,15 @@ type ThriftConfig struct {
 	DebugClientProtocol bool
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func WithDefaults() *Config {
 	return &Config{
 		Port:     443,
 		MaxRows:  10000,
-		Database: "default",
+		Catalog:  strPtr("default"),
 		Protocol: "https",
 		RunAsync: true,
 		Thrift: &ThriftConfig{
@@ -80,7 +84,7 @@ func (c *Config) DeepCopy() *Config {
 		Host:           c.Host,
 		Port:           c.Port,
 		Catalog:        c.Catalog,
-		Database:       c.Database,
+		Schema:         c.Schema,
 		AccessToken:    c.AccessToken,
 		TLSConfig:      c.TLSConfig.Clone(),
 		Protocol:       c.Protocol,

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -86,7 +86,7 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 		select {
 		case <-intervalTimer.C:
 			done, statusResp, err := s.StatusFn()
-			log.Debug().Msg("status checked")
+			log.Debug().Msg("databricks: status checked")
 			if err != nil {
 				return WatchErr, statusResp, err
 			}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Guid []byte
 


### PR DESCRIPTION
Implementing Ping and Close methods in connection.
Added support for catalog and schema definition:

```go
func WithInitialNamespace(catalog, schema string) connOption {
	return func(c *config.Config) {
		if catalog != "" {
			c.Catalog = &catalog
		}
		if schema != "" {
			c.Schema = &schema
		}
	}
}
```

Signed-off-by: Andre Furlan <andre.furlan@databricks.com>