### PR TITLE
Configurable logging

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -265,7 +265,7 @@ func (c *conn) pollOperation(ctx context.Context, opHandle *cli_service.TOperati
 		},
 		OnCancelFn: func() (any, error) {
 			logger.Debug().Msgf("databricks: canceling operation %s", opHandle.OperationId)
-			ret, err := c.client.CancelOperation(context.Background(), &ts.TCancelOperationReq{
+			ret, err := c.client.CancelOperation(context.Background(), &cli_service.TCancelOperationReq{
 				OperationHandle: opHandle,
 			})
 			return ret, err

--- a/connection.go
+++ b/connection.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog/log"
-
 	"github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
+	"github.com/databricks/databricks-sql-go/logger"
+	"github.com/rs/zerolog/log"
 )
 
 type conn struct {
@@ -60,7 +60,7 @@ func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 func (c *conn) Ping(ctx context.Context) error {
 	_, err := c.QueryContext(ctx, "select 1", nil)
 	if err != nil {
-		log.Err(err).Msg("ping error")
+		logger.Log.Err(err).Msg("ping error")
 		return driver.ErrBadConn
 	}
 	return nil
@@ -151,8 +151,8 @@ func (c *conn) runQuery(ctx context.Context, query string, args []driver.NamedVa
 		// bad
 		case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
 			// do we need to close the operation in these cases?
-			log.Debug().Msgf("bad state: %s", opStatus.GetOperationState())
-			log.Error().Msg(opStatus.GetErrorMessage())
+			logger.Log.Error().Msg(opStatus.GetErrorMessage())
+			logger.Log.Debug().Msgf("bad state: %s", opStatus.GetOperationState())
 
 			return exStmtResp, opStatus, fmt.Errorf(opStatus.GetDisplayMessage())
 		// live states
@@ -169,19 +169,19 @@ func (c *conn) runQuery(ctx context.Context, query string, args []driver.NamedVa
 				return exStmtResp, opStatus, nil
 			// bad
 			case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
-				log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
-				log.Error().Msg(statusResp.GetErrorMessage())
+				logger.Log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
+				logger.Log.Error().Msg(statusResp.GetErrorMessage())
 				return exStmtResp, opStatus, fmt.Errorf(statusResp.GetDisplayMessage())
 				// live states
 			default:
-				log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
-				log.Error().Msg(statusResp.GetErrorMessage())
+				logger.Log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
+				logger.Log.Error().Msg(statusResp.GetErrorMessage())
 				return exStmtResp, opStatus, fmt.Errorf("invalid operation state. This should not have happened")
 			}
 		// weird states
 		default:
-			log.Debug().Msgf("bad state: %s", opStatus.GetOperationState())
-			log.Error().Msg(opStatus.GetErrorMessage())
+			logger.Log.Debug().Msgf("bad state: %s", opStatus.GetOperationState())
+			logger.Log.Error().Msg(opStatus.GetErrorMessage())
 			return exStmtResp, opStatus, fmt.Errorf("invalid operation state. This should not have happened")
 		}
 
@@ -198,13 +198,13 @@ func (c *conn) runQuery(ctx context.Context, query string, args []driver.NamedVa
 			return exStmtResp, statusResp, nil
 		// bad
 		case cli_service.TOperationState_CANCELED_STATE, cli_service.TOperationState_CLOSED_STATE, cli_service.TOperationState_ERROR_STATE, cli_service.TOperationState_TIMEDOUT_STATE:
-			log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
-			log.Error().Msg(statusResp.GetErrorMessage())
+			logger.Log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
+			logger.Log.Error().Msg(statusResp.GetErrorMessage())
 			return exStmtResp, statusResp, fmt.Errorf(statusResp.GetDisplayMessage())
 			// live states
 		default:
-			log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
-			log.Error().Msg(statusResp.GetErrorMessage())
+			logger.Log.Debug().Msgf("bad state: %s", statusResp.GetOperationState())
+			logger.Log.Error().Msg(statusResp.GetErrorMessage())
 			return exStmtResp, statusResp, fmt.Errorf("invalid operation state. This should not have happened")
 		}
 	}
@@ -249,7 +249,7 @@ func (c *conn) pollOperation(ctx context.Context, opHandle *cli_service.TOperati
 		},
 		StatusFn: func() (sentinel.Done, any, error) {
 			var err error
-			log.Debug().Msg("databricks: polling status")
+			logger.Log.Debug().Msg("databricks: polling status")
 			statusResp, err = c.client.GetOperationStatus(context.Background(), &cli_service.TGetOperationStatusReq{
 				OperationHandle: opHandle,
 			})
@@ -259,7 +259,7 @@ func (c *conn) pollOperation(ctx context.Context, opHandle *cli_service.TOperati
 				case cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE, cli_service.TOperationState_RUNNING_STATE:
 					return false
 				default:
-					log.Debug().Msg("databricks: polling done")
+					logger.Log.Debug().Msg("databricks: polling done")
 					return true
 				}
 			}, statusResp, err

--- a/connector.go
+++ b/connector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
+	"github.com/databricks/databricks-sql-go/logger"
 	"github.com/rs/zerolog/log"
 )
 
@@ -68,7 +69,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Info().Msgf("session parameters: %s", setStmt)
+		logger.Log.Info().Msgf("session parameters: %s", setStmt)
 	}
 
 	return conn, nil

--- a/connector.go
+++ b/connector.go
@@ -11,7 +11,6 @@ import (
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
 	"github.com/databricks/databricks-sql-go/logger"
-	"github.com/rs/zerolog/log"
 )
 
 type connector struct {
@@ -56,7 +55,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	if !ok {
 		return nil, fmt.Errorf("databricks: invalid open session response")
 	}
-	log.Info().Msgf("open session: %s\n", utils.Guid(session.SessionHandle.GetSessionId().GUID))
+	logger.Info().Msgf("open session: %s\n", utils.Guid(session.SessionHandle.GetSessionId().GUID))
 
 	conn := &conn{
 		cfg:     c.cfg,
@@ -69,7 +68,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		logger.Log.Info().Msgf("session parameters: %s", setStmt)
+		logger.Info().Msgf("session parameters: %s", setStmt)
 	}
 
 	return conn, nil

--- a/driver.go
+++ b/driver.go
@@ -6,9 +6,12 @@ import (
 	"database/sql/driver"
 
 	"github.com/databricks/databricks-sql-go/internal/config"
+	"github.com/databricks/databricks-sql-go/utils"
+	"github.com/rs/zerolog"
 )
 
 func init() {
+	utils.ConfigureLogger()
 	sql.Register("databricks", &databricksDriver{})
 }
 
@@ -39,3 +42,7 @@ func (d *databricksDriver) OpenConnector(dsn string) (driver.Connector, error) {
 
 var _ driver.Driver = (*databricksDriver)(nil)
 var _ driver.DriverContext = (*databricksDriver)(nil)
+
+func GetLogger() zerolog.Logger {
+	return utils.Logger
+}

--- a/driver.go
+++ b/driver.go
@@ -6,12 +6,11 @@ import (
 	"database/sql/driver"
 
 	"github.com/databricks/databricks-sql-go/internal/config"
-	"github.com/databricks/databricks-sql-go/utils"
+	"github.com/databricks/databricks-sql-go/logger"
 	"github.com/rs/zerolog"
 )
 
 func init() {
-	utils.ConfigureLogger()
 	sql.Register("databricks", &databricksDriver{})
 }
 
@@ -44,5 +43,5 @@ var _ driver.Driver = (*databricksDriver)(nil)
 var _ driver.DriverContext = (*databricksDriver)(nil)
 
 func GetLogger() zerolog.Logger {
-	return utils.Logger
+	return logger.Log
 }

--- a/driver.go
+++ b/driver.go
@@ -6,8 +6,7 @@ import (
 	"database/sql/driver"
 
 	"github.com/databricks/databricks-sql-go/internal/config"
-	"github.com/databricks/databricks-sql-go/logger"
-	"github.com/rs/zerolog"
+	_ "github.com/databricks/databricks-sql-go/logger"
 )
 
 func init() {
@@ -41,7 +40,3 @@ func (d *databricksDriver) OpenConnector(dsn string) (driver.Connector, error) {
 
 var _ driver.Driver = (*databricksDriver)(nil)
 var _ driver.DriverContext = (*databricksDriver)(nil)
-
-func GetLogger() zerolog.Logger {
-	return logger.Log
-}

--- a/examples/timezone/main.go
+++ b/examples/timezone/main.go
@@ -12,18 +12,19 @@ import (
 	dbsql "github.com/databricks/databricks-sql-go"
 	dbsqllog "github.com/databricks/databricks-sql-go/logger"
 	"github.com/joho/godotenv"
-	"github.com/rs/zerolog"
 )
 
 func main() {
 	// Opening a driver typically will not attempt to connect to the database.
 	err := godotenv.Load()
-
-	dbsqllog.SetLogLevel(zerolog.DebugLevel)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+
+	if err := dbsqllog.SetLogLevel("info"); err != nil {
+		log.Println(err)
+	}
+
 	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
 	if err != nil {
 		log.Fatal(err.Error())

--- a/examples/timezone/main.go
+++ b/examples/timezone/main.go
@@ -10,12 +10,16 @@ import (
 	"time"
 
 	dbsql "github.com/databricks/databricks-sql-go"
+	dbsqllog "github.com/databricks/databricks-sql-go/logger"
 	"github.com/joho/godotenv"
+	"github.com/rs/zerolog"
 )
 
 func main() {
 	// Opening a driver typically will not attempt to connect to the database.
 	err := godotenv.Load()
+
+	dbsqllog.SetLogLevel(zerolog.DebugLevel)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,17 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/databricks/databricks-sql-go/internal/cli_service"
-	ts "github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/databricks/databricks-sql-go/internal/config"
 )
 
 type ThriftServiceClient struct {
-	*ts.TCLIServiceClient
+	*cli_service.TCLIServiceClient
 }
 
 func (tsc *ThriftServiceClient) FetchResults(ctx context.Context, req *cli_service.TFetchResultsReq) (*cli_service.TFetchResultsResp, error) {
@@ -116,7 +114,7 @@ func InitThriftClient(cfg *config.Config) (*ThriftServiceClient, error) {
 	}
 	iprot := protocolFactory.GetProtocol(tTrans)
 	oprot := protocolFactory.GetProtocol(tTrans)
-	tclient := ts.NewTCLIServiceClient(thrift.NewTStandardClient(iprot, oprot))
+	tclient := cli_service.NewTCLIServiceClient(thrift.NewTStandardClient(iprot, oprot))
 	tsClient := &ThriftServiceClient{tclient}
 	return tsClient, nil
 }
@@ -141,6 +139,5 @@ func CheckStatus(resp interface{}) error {
 		return nil
 	}
 
-	log.Printf("response: %v", resp)
 	return errors.New("thrift: invalid response")
 }

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/databricks/databricks-sql-go/utils"
+	"github.com/databricks/databricks-sql-go/logger"
 )
 
 const (
@@ -115,7 +115,7 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 			return WatchCanceled, nil, ctx.Err()
 		case <-timeoutTimerCh:
 			_ = intervalTimer.Stop()
-			utils.Logger.Info().Msgf("wait timed out after %s", timeout.String())
+			logger.Log.Info().Msgf("wait timed out after %s", timeout.String())
 			return WatchTimeout, nil, fmt.Errorf("sentinel timed out")
 		}
 	}

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -115,7 +115,7 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 			return WatchCanceled, nil, ctx.Err()
 		case <-timeoutTimerCh:
 			_ = intervalTimer.Stop()
-			logger.Log.Info().Msgf("wait timed out after %s", timeout.String())
+			logger.Info().Msgf("wait timed out after %s", timeout.String())
 			return WatchTimeout, nil, fmt.Errorf("sentinel timed out")
 		}
 	}

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"github.com/databricks/databricks-sql-go/utils"
 )
 
 const (
@@ -115,7 +115,7 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 			return WatchCanceled, nil, ctx.Err()
 		case <-timeoutTimerCh:
 			_ = intervalTimer.Stop()
-			log.Info().Msgf("wait timed out after %s", timeout.String())
+			utils.Logger.Info().Msgf("wait timed out after %s", timeout.String())
 			return WatchTimeout, nil, fmt.Errorf("sentinel timed out")
 		}
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,4 +1,4 @@
-package utils
+package internal
 
 import (
 	"fmt"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,7 @@
-package utils
+package logger
 
 import (
+	"io"
 	"os"
 	"runtime"
 
@@ -8,18 +9,27 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+var Log = zerolog.New(os.Stderr).With().Timestamp().Logger()
 
-// ConfigureGlobalLogger will configure zerolog globally. It will
 // enable pretty printing for interactive terminals and json for production.
-func ConfigureLogger() {
+func init() {
 	// for tty terminal enable pretty logs
 	if isatty.IsTerminal(os.Stdout.Fd()) && runtime.GOOS != "windows" {
-		Logger = Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+		Log = Log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	} else {
 		// UNIX Time is faster and smaller than most timestamps
 		// If you set zerolog.TimeFieldFormat to an empty string,
 		// logs will write with UNIX time.
 		zerolog.TimeFieldFormat = ""
 	}
+	// by default only log error
+	SetLogLevel(zerolog.WarnLevel)
+}
+
+func SetLogLevel(l zerolog.Level) {
+	Log = Log.Level(l)
+}
+
+func SetLogOutput(w io.Writer) {
+	Log = Log.Output(w)
 }

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -1,4 +1,4 @@
-package dbsql
+package utils
 
 import (
 	"os"
@@ -6,15 +6,16 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
+
+var Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
 
 // ConfigureGlobalLogger will configure zerolog globally. It will
 // enable pretty printing for interactive terminals and json for production.
-func ConfigureGlobalLogger() {
+func ConfigureLogger() {
 	// for tty terminal enable pretty logs
 	if isatty.IsTerminal(os.Stdout.Fd()) && runtime.GOOS != "windows" {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+		Logger = Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	} else {
 		// UNIX Time is faster and smaller than most timestamps
 		// If you set zerolog.TimeFieldFormat to an empty string,


### PR DESCRIPTION
Adding a logger package that is exposed publicly so our users can set log levels and output writers.
<img width="507" alt="Screen Shot 2022-11-09 at 2 37 37 PM" src="https://user-images.githubusercontent.com/115681926/200959763-d328a961-514c-40da-8a54-f9452e4f054f.png">

Levels can be set by using `DATABRICKS_LOG_LEVEL` environment variable or calling `SetLogLevel`
```go
if err := dbsqllog.SetLogLevel("info"); err != nil {
   log.Println(err)
}
```



Signed-off-by: Andre Furlan <andre.furlan@databricks.com>