### PR TITLE
adding location to user config

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -115,6 +115,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		client:   c.client,
 		opHandle: opHandle,
 		pageSize: int64(c.cfg.MaxRows),
+		location: c.cfg.Location,
 	}
 
 	if exStmtResp.DirectResults != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ type UserConfig struct {
 	MaxRows             int    // TODO
 	QueryTimeoutSeconds int    // There are several timeouts that can be possibly configurable
 	UserAgentEntry      string
+	Location            *time.Location
 	SessionParams       map[string]string
 }
 
@@ -184,6 +185,10 @@ func ParseDSN(dsn string) (UserConfig, error) {
 		ucfg.Schema = params.Get("schema")
 		params.Del("schema")
 	}
+	if params.Has("timezone") {
+		tz := params.Get("timezone")
+		ucfg.Location, err = time.LoadLocation(tz)
+	}
 	if len(params) > 0 {
 		sessionParams := make(map[string]string)
 		for k := range params {
@@ -193,5 +198,5 @@ func ParseDSN(dsn string) (UserConfig, error) {
 
 	}
 
-	return ucfg, nil
+	return ucfg, err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,12 +3,14 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestParseConfig(t *testing.T) {
 	type args struct {
 		dsn string
 	}
+	tz, _ := time.LoadLocation("America/Vancouver")
 	tests := []struct {
 		name    string
 		args    args
@@ -82,7 +84,7 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name: "with query params and session params",
-			args: args{dsn: "token:supersecret@example.cloud.databricks.com:8000/sql/1.0/endpoints/12346a5b5b0e123a?timeout=100&maxRows=1000&timezone=PST"},
+			args: args{dsn: "token:supersecret@example.cloud.databricks.com:8000/sql/1.0/endpoints/12346a5b5b0e123a?timeout=100&maxRows=1000&timezone=America/Vancouver"},
 			wantCfg: UserConfig{
 				Protocol:            "https",
 				Host:                "example.cloud.databricks.com",
@@ -91,7 +93,8 @@ func TestParseConfig(t *testing.T) {
 				HTTPPath:            "/sql/1.0/endpoints/12346a5b5b0e123a",
 				QueryTimeoutSeconds: 100,
 				MaxRows:             1000,
-				SessionParams:       map[string]string{"timezone": "PST"},
+				Location:            tz,
+				SessionParams:       map[string]string{"timezone": "America/Vancouver"},
 			},
 			wantURL: "https://token:supersecret@example.cloud.databricks.com:8000/sql/1.0/endpoints/12346a5b5b0e123a",
 			wantErr: false,


### PR DESCRIPTION
Adding location property to config of type `time.Location` so session param timezone can be used to parse dates and timestamps. 

Signed-off-by: Andre Furlan <andre.furlan@databricks.com>