### PR TITLE
Tests for connection.go (ExecContext, QueryContext)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sql-go/internal/cli_service"
-	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
 	"github.com/databricks/databricks-sql-go/logger"
@@ -15,7 +14,7 @@ import (
 
 type conn struct {
 	cfg     *config.Config
-	client  *client.ThriftServiceClient
+	client  cli_service.TCLIService
 	session *cli_service.TOpenSessionResp
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -777,7 +777,7 @@ func TestConn_ExecContext(t *testing.T) {
 			cfg:     config.WithDefaults(),
 		}
 		res, err := testConn.ExecContext(context.Background(), "select 1", []driver.NamedValue{
-			driver.NamedValue{Value: 1, Name: "name"},
+			{Value: 1, Name: "name"},
 		})
 
 		assert.Error(t, err)
@@ -875,7 +875,7 @@ func TestConn_QueryContext(t *testing.T) {
 			cfg:     config.WithDefaults(),
 		}
 		res, err := testConn.ExecContext(context.Background(), "select 1", []driver.NamedValue{
-			driver.NamedValue{Value: 1, Name: "name"},
+			{Value: 1, Name: "name"},
 		})
 
 		assert.Error(t, err)

--- a/connection_test.go
+++ b/connection_test.go
@@ -298,7 +298,8 @@ func TestConn_pollOperation(t *testing.T) {
 			client:  testClient,
 			cfg:     config.WithDefaults(),
 		}
-		ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
 		res, err := testConn.pollOperation(ctx, &cli_service.TOperationHandle{
 			OperationId: &cli_service.THandleIdentifier{
 				GUID:   []byte("2"),
@@ -340,7 +341,8 @@ func TestConn_pollOperation(t *testing.T) {
 			client:  testClient,
 			cfg:     config.WithDefaults(),
 		}
-		ctx, _ := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
 		res, err := testConn.pollOperation(ctx, &cli_service.TOperationHandle{
 			OperationId: &cli_service.THandleIdentifier{
 				GUID:   []byte("2"),
@@ -383,6 +385,7 @@ func TestConn_pollOperation(t *testing.T) {
 			cfg:     config.WithDefaults(),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		go func() {
 			time.Sleep(250 * time.Millisecond)
 			cancel()

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,1 +1,662 @@
 package dbsql
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"github.com/apache/thrift/lib/go/thrift"
+	"testing"
+	"time"
+
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	"github.com/databricks/databricks-sql-go/internal/client"
+	"github.com/databricks/databricks-sql-go/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConn_executeStatement(t *testing.T) {
+	t.Run("executeStatement should err when client.ExecuteStatement fails", func(t *testing.T) {
+		var executeStatementCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			return nil, fmt.Errorf("error")
+		}
+		testClient := &client.TestClient{
+			FnExecuteStatement: executeStatement,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		_, err := testConn.executeStatement(context.Background(), "select 1", []driver.NamedValue{})
+		assert.Error(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+	})
+
+	t.Run("executeStatement should return TExecuteStatementResp on success", func(t *testing.T) {
+		var executeStatementCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+				DirectResults: &cli_service.TSparkDirectResults{
+					OperationStatus: &cli_service.TGetOperationStatusResp{
+						Status: &cli_service.TStatus{
+							StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+						},
+						OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_ERROR_STATE),
+						ErrorMessage:   strPtr("error message"),
+						DisplayMessage: strPtr("display message"),
+					},
+					ResultSetMetadata: &cli_service.TGetResultSetMetadataResp{
+						Status: &cli_service.TStatus{
+							StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+						},
+					},
+					ResultSet: &cli_service.TFetchResultsResp{
+						Status: &cli_service.TStatus{
+							StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+						},
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+		testClient := &client.TestClient{
+			FnExecuteStatement: executeStatement,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		_, err := testConn.executeStatement(context.Background(), "select 1", []driver.NamedValue{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+	})
+}
+
+func TestConn_pollOperation(t *testing.T) {
+	t.Run("pollOperation returns finished state response when query finishes", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns closed state response when query has been closed", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_CLOSED_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_CLOSED_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns closed state response when query has been closed", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_CLOSED_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_CLOSED_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns unknown state response when query state is unknown", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_UKNOWN_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_UKNOWN_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns error state response when query errors", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_ERROR_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_ERROR_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns finished state response after query cycles through various states", func(t *testing.T) {
+		var getOperationStatusCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			operationStates := [4]cli_service.TOperationState{cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE,
+				cli_service.TOperationState_RUNNING_STATE, cli_service.TOperationState_FINISHED_STATE}
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(operationStates[getOperationStatusCount-1]),
+			}
+			return getOperationStatusResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.pollOperation(context.Background(), &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 4, getOperationStatusCount)
+		assert.Equal(t, cli_service.TGetOperationStatusResp{
+			OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+		}, *res)
+	})
+
+	t.Run("pollOperation returns cancel err when context times out before get operation", func(t *testing.T) {
+		var getOperationStatusCount, cancelOperationCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			operationStates := [4]cli_service.TOperationState{cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE,
+				cli_service.TOperationState_RUNNING_STATE, cli_service.TOperationState_FINISHED_STATE}
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(operationStates[getOperationStatusCount-1]),
+			}
+			return getOperationStatusResp, nil
+		}
+		cancelOperation := func(ctx context.Context, req *cli_service.TCancelOperationReq) (r *cli_service.TCancelOperationResp, err error) {
+			cancelOperationCount++
+			cancelOperationResp := &cli_service.TCancelOperationResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+			}
+			return cancelOperationResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+			FnCancelOperation:    cancelOperation,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		res, err := testConn.pollOperation(ctx, &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 0, getOperationStatusCount)
+		assert.Equal(t, 1, cancelOperationCount)
+		assert.Nil(t, res)
+	})
+
+	t.Run("pollOperation returns cancel err when context times out before get operation", func(t *testing.T) {
+		var getOperationStatusCount, cancelOperationCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			operationStates := [4]cli_service.TOperationState{cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE,
+				cli_service.TOperationState_RUNNING_STATE, cli_service.TOperationState_FINISHED_STATE}
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(operationStates[getOperationStatusCount-1]),
+			}
+			return getOperationStatusResp, nil
+		}
+		cancelOperation := func(ctx context.Context, req *cli_service.TCancelOperationReq) (r *cli_service.TCancelOperationResp, err error) {
+			cancelOperationCount++
+			cancelOperationResp := &cli_service.TCancelOperationResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+			}
+			return cancelOperationResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+			FnCancelOperation:    cancelOperation,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		res, err := testConn.pollOperation(ctx, &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.GreaterOrEqual(t, 1, cancelOperationCount)
+		assert.Nil(t, res)
+	})
+
+	t.Run("pollOperation returns cancel err when context is cancelled", func(t *testing.T) {
+		var getOperationStatusCount, cancelOperationCount int
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			operationStates := [4]cli_service.TOperationState{cli_service.TOperationState_INITIALIZED_STATE, cli_service.TOperationState_PENDING_STATE,
+				cli_service.TOperationState_RUNNING_STATE, cli_service.TOperationState_FINISHED_STATE}
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(operationStates[getOperationStatusCount-1]),
+			}
+			return getOperationStatusResp, nil
+		}
+		cancelOperation := func(ctx context.Context, req *cli_service.TCancelOperationReq) (r *cli_service.TCancelOperationResp, err error) {
+			cancelOperationCount++
+			cancelOperationResp := &cli_service.TCancelOperationResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+			}
+			return cancelOperationResp, nil
+		}
+		testClient := &client.TestClient{
+			FnGetOperationStatus: getOperationStatus,
+			FnCancelOperation:    cancelOperation,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(250 * time.Millisecond)
+			cancel()
+		}()
+		res, err := testConn.pollOperation(ctx, &cli_service.TOperationHandle{
+			OperationId: &cli_service.THandleIdentifier{
+				GUID:   []byte("2"),
+				Secret: []byte("b"),
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.GreaterOrEqual(t, 1, cancelOperationCount)
+		assert.Nil(t, res)
+	})
+}
+
+func TestConn_runQuery(t *testing.T) {
+	t.Run("runQuery should err when client.ExecuteStatement fails", func(t *testing.T) {
+		var executeStatementCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			return nil, fmt.Errorf("error")
+		}
+		testClient := &client.TestClient{
+			FnExecuteStatement: executeStatement,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		exStmtResp, opStatusResp, err := testConn.runQuery(context.Background(), "select 1", []driver.NamedValue{})
+		assert.Error(t, err)
+		assert.Nil(t, exStmtResp)
+		assert.Nil(t, opStatusResp)
+		assert.Equal(t, 1, executeStatementCount)
+	})
+
+	t.Run("runQuery should err when pollOperation fails", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_ERROR_STATE),
+			}
+			return getOperationStatusResp, fmt.Errorf("error on get operation status")
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		exStmtResp, opStatusResp, err := testConn.runQuery(context.Background(), "select 1", []driver.NamedValue{})
+
+		assert.Error(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.NotNil(t, exStmtResp)
+		assert.Nil(t, opStatusResp)
+	})
+
+	t.Run("runQuery should return resp when query is finished", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		exStmtResp, opStatusResp, err := testConn.runQuery(context.Background(), "select 1", []driver.NamedValue{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.NotNil(t, exStmtResp)
+		assert.NotNil(t, opStatusResp)
+	})
+
+	t.Run("runQuery should return resp and error when query is canceled", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState: cli_service.TOperationStatePtr(cli_service.TOperationState_CANCELED_STATE),
+			}
+			return getOperationStatusResp, nil
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		exStmtResp, opStatusResp, err := testConn.runQuery(context.Background(), "select 1", []driver.NamedValue{})
+
+		assert.Error(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, 1, getOperationStatusCount)
+		assert.NotNil(t, exStmtResp)
+		assert.NotNil(t, opStatusResp)
+	})
+}
+
+func TestConn_ExecContext(t *testing.T) {
+	t.Run("ExecContext currently does not support query parameters", func(t *testing.T) {
+		var executeStatementCount int
+
+		testClient := &client.TestClient{}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.ExecContext(context.Background(), "select 1", []driver.NamedValue{
+			driver.NamedValue{Value: 1, Name: "name"},
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, res)
+		assert.Equal(t, 0, executeStatementCount)
+	})
+
+	t.Run("ExecContext returns err when client.ExecuteStatement fails", func(t *testing.T) {
+		var executeStatementCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_ERROR_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, fmt.Errorf("error")
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement: executeStatement,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.ExecContext(context.Background(), "select 1", []driver.NamedValue{})
+
+		assert.Error(t, err)
+		assert.Nil(t, res)
+		assert.Equal(t, 1, executeStatementCount)
+	})
+
+	t.Run("ExecContext returns number of rows modified when execution is successful", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte("2"),
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState:  cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+				NumModifiedRows: thrift.Int64Ptr(10),
+			}
+			return getOperationStatusResp, nil
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		res, err := testConn.ExecContext(context.Background(), "insert 10", []driver.NamedValue{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		rowsAffected, _ := res.RowsAffected()
+		assert.Equal(t, int64(10), rowsAffected)
+		assert.Equal(t, 1, executeStatementCount)
+	})
+}
+
+func getTestSession() *cli_service.TOpenSessionResp {
+	return &cli_service.TOpenSessionResp{SessionHandle: &cli_service.TSessionHandle{
+		SessionId: &cli_service.THandleIdentifier{
+			GUID: []byte("foo"),
+		},
+	}}
+}

--- a/internal/client/test_client.go
+++ b/internal/client/test_client.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+)
+
+var ErrNotImplemented = errors.New("databricks: not implemented")
+
+type TestClient struct {
+	FnOpenSession           func(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error)
+	FnCloseSession          func(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error)
+	FnGetInfo               func(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error)
+	FnExecuteStatement      func(ctx context.Context, req *cli_service.TExecuteStatementReq) (_r *cli_service.TExecuteStatementResp, _err error)
+	FnGetTypeInfo           func(ctx context.Context, req *cli_service.TGetTypeInfoReq) (_r *cli_service.TGetTypeInfoResp, _err error)
+	FnGetCatalogs           func(ctx context.Context, req *cli_service.TGetCatalogsReq) (_r *cli_service.TGetCatalogsResp, _err error)
+	FnGetSchemas            func(ctx context.Context, req *cli_service.TGetSchemasReq) (_r *cli_service.TGetSchemasResp, _err error)
+	FnGetTables             func(ctx context.Context, req *cli_service.TGetTablesReq) (_r *cli_service.TGetTablesResp, _err error)
+	FnGetTableTypes         func(ctx context.Context, req *cli_service.TGetTableTypesReq) (_r *cli_service.TGetTableTypesResp, _err error)
+	FnGetColumns            func(ctx context.Context, req *cli_service.TGetColumnsReq) (_r *cli_service.TGetColumnsResp, _err error)
+	FnGetFunctions          func(ctx context.Context, req *cli_service.TGetFunctionsReq) (_r *cli_service.TGetFunctionsResp, _err error)
+	FnGetPrimaryKeys        func(ctx context.Context, req *cli_service.TGetPrimaryKeysReq) (_r *cli_service.TGetPrimaryKeysResp, _err error)
+	FnGetCrossReference     func(ctx context.Context, req *cli_service.TGetCrossReferenceReq) (_r *cli_service.TGetCrossReferenceResp, _err error)
+	FnGetOperationStatus    func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (_r *cli_service.TGetOperationStatusResp, _err error)
+	FnCancelOperation       func(ctx context.Context, req *cli_service.TCancelOperationReq) (_r *cli_service.TCancelOperationResp, _err error)
+	FnCloseOperation        func(ctx context.Context, req *cli_service.TCloseOperationReq) (_r *cli_service.TCloseOperationResp, _err error)
+	FnGetResultSetMetadata  func(ctx context.Context, req *cli_service.TGetResultSetMetadataReq) (_r *cli_service.TGetResultSetMetadataResp, _err error)
+	FnFetchResults          func(ctx context.Context, req *cli_service.TFetchResultsReq) (_r *cli_service.TFetchResultsResp, _err error)
+	FnGetDelegationToken    func(ctx context.Context, req *cli_service.TGetDelegationTokenReq) (_r *cli_service.TGetDelegationTokenResp, _err error)
+	FnCancelDelegationToken func(ctx context.Context, req *cli_service.TCancelDelegationTokenReq) (_r *cli_service.TCancelDelegationTokenResp, _err error)
+	FnRenewDelegationToken  func(ctx context.Context, req *cli_service.TRenewDelegationTokenReq) (_r *cli_service.TRenewDelegationTokenResp, _err error)
+}
+
+var _ cli_service.TCLIService = (*TestClient)(nil)
+
+func (c *TestClient) OpenSession(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error) {
+	if c.FnOpenSession != nil {
+		return c.FnOpenSession(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) CloseSession(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error) {
+	if c.FnCloseSession != nil {
+		return c.FnCloseSession(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetInfo(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error) {
+	if c.FnGetInfo != nil {
+		return c.FnGetInfo(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) ExecuteStatement(ctx context.Context, req *cli_service.TExecuteStatementReq) (_r *cli_service.TExecuteStatementResp, _err error) {
+	if c.FnExecuteStatement != nil {
+		return c.FnExecuteStatement(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetTypeInfo(ctx context.Context, req *cli_service.TGetTypeInfoReq) (_r *cli_service.TGetTypeInfoResp, _err error) {
+	if c.FnGetTypeInfo != nil {
+		return c.FnGetTypeInfo(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetCatalogs(ctx context.Context, req *cli_service.TGetCatalogsReq) (_r *cli_service.TGetCatalogsResp, _err error) {
+	if c.FnGetCatalogs != nil {
+		return c.FnGetCatalogs(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetSchemas(ctx context.Context, req *cli_service.TGetSchemasReq) (_r *cli_service.TGetSchemasResp, _err error) {
+	if c.FnGetSchemas != nil {
+		return c.FnGetSchemas(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetTables(ctx context.Context, req *cli_service.TGetTablesReq) (_r *cli_service.TGetTablesResp, _err error) {
+	if c.FnGetTables != nil {
+		return c.FnGetTables(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetTableTypes(ctx context.Context, req *cli_service.TGetTableTypesReq) (_r *cli_service.TGetTableTypesResp, _err error) {
+	if c.FnGetTableTypes != nil {
+		return c.FnGetTableTypes(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetColumns(ctx context.Context, req *cli_service.TGetColumnsReq) (_r *cli_service.TGetColumnsResp, _err error) {
+	if c.FnGetColumns != nil {
+		return c.FnGetColumns(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetFunctions(ctx context.Context, req *cli_service.TGetFunctionsReq) (_r *cli_service.TGetFunctionsResp, _err error) {
+	if c.FnGetFunctions != nil {
+		return c.FnGetFunctions(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetPrimaryKeys(ctx context.Context, req *cli_service.TGetPrimaryKeysReq) (_r *cli_service.TGetPrimaryKeysResp, _err error) {
+	if c.FnGetPrimaryKeys != nil {
+		return c.FnGetPrimaryKeys(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetCrossReference(ctx context.Context, req *cli_service.TGetCrossReferenceReq) (_r *cli_service.TGetCrossReferenceResp, _err error) {
+	if c.FnGetCrossReference != nil {
+		return c.FnGetCrossReference(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetOperationStatus(ctx context.Context, req *cli_service.TGetOperationStatusReq) (_r *cli_service.TGetOperationStatusResp, _err error) {
+	if c.FnGetOperationStatus != nil {
+		return c.FnGetOperationStatus(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) CancelOperation(ctx context.Context, req *cli_service.TCancelOperationReq) (_r *cli_service.TCancelOperationResp, _err error) {
+	if c.FnCancelOperation != nil {
+		return c.FnCancelOperation(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) CloseOperation(ctx context.Context, req *cli_service.TCloseOperationReq) (_r *cli_service.TCloseOperationResp, _err error) {
+	if c.FnCloseOperation != nil {
+		return c.FnCloseOperation(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetResultSetMetadata(ctx context.Context, req *cli_service.TGetResultSetMetadataReq) (_r *cli_service.TGetResultSetMetadataResp, _err error) {
+	if c.FnGetResultSetMetadata != nil {
+		return c.FnGetResultSetMetadata(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) FetchResults(ctx context.Context, req *cli_service.TFetchResultsReq) (_r *cli_service.TFetchResultsResp, _err error) {
+	if c.FnFetchResults != nil {
+		return c.FnFetchResults(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) GetDelegationToken(ctx context.Context, req *cli_service.TGetDelegationTokenReq) (_r *cli_service.TGetDelegationTokenResp, _err error) {
+	if c.FnGetDelegationToken != nil {
+		return c.FnGetDelegationToken(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) CancelDelegationToken(ctx context.Context, req *cli_service.TCancelDelegationTokenReq) (_r *cli_service.TCancelDelegationTokenResp, _err error) {
+	if c.FnCancelDelegationToken != nil {
+		return c.FnCancelDelegationToken(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}
+func (c *TestClient) RenewDelegationToken(ctx context.Context, req *cli_service.TRenewDelegationTokenReq) (_r *cli_service.TRenewDelegationTokenResp, _err error) {
+	if c.FnRenewDelegationToken != nil {
+		return c.FnRenewDelegationToken(ctx, req)
+	}
+	return nil, ErrNotImplemented
+}

--- a/rows_test.go
+++ b/rows_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"github.com/databricks/databricks-sql-go/internal/client"
 	"io"
 	"math"
 	"reflect"
@@ -770,159 +771,6 @@ func (rt rowTestPagingResult) validatePaging(t *testing.T, rowSet *rows, err err
 	}
 }
 
-type rowTestClient struct {
-	fOpenSession           func(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error)
-	fCloseSession          func(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error)
-	fGetInfo               func(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error)
-	fExecuteStatement      func(ctx context.Context, req *cli_service.TExecuteStatementReq) (_r *cli_service.TExecuteStatementResp, _err error)
-	fGetTypeInfo           func(ctx context.Context, req *cli_service.TGetTypeInfoReq) (_r *cli_service.TGetTypeInfoResp, _err error)
-	fGetCatalogs           func(ctx context.Context, req *cli_service.TGetCatalogsReq) (_r *cli_service.TGetCatalogsResp, _err error)
-	fGetSchemas            func(ctx context.Context, req *cli_service.TGetSchemasReq) (_r *cli_service.TGetSchemasResp, _err error)
-	fGetTables             func(ctx context.Context, req *cli_service.TGetTablesReq) (_r *cli_service.TGetTablesResp, _err error)
-	fGetTableTypes         func(ctx context.Context, req *cli_service.TGetTableTypesReq) (_r *cli_service.TGetTableTypesResp, _err error)
-	fGetColumns            func(ctx context.Context, req *cli_service.TGetColumnsReq) (_r *cli_service.TGetColumnsResp, _err error)
-	fGetFunctions          func(ctx context.Context, req *cli_service.TGetFunctionsReq) (_r *cli_service.TGetFunctionsResp, _err error)
-	fGetPrimaryKeys        func(ctx context.Context, req *cli_service.TGetPrimaryKeysReq) (_r *cli_service.TGetPrimaryKeysResp, _err error)
-	fGetCrossReference     func(ctx context.Context, req *cli_service.TGetCrossReferenceReq) (_r *cli_service.TGetCrossReferenceResp, _err error)
-	fGetOperationStatus    func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (_r *cli_service.TGetOperationStatusResp, _err error)
-	fCancelOperation       func(ctx context.Context, req *cli_service.TCancelOperationReq) (_r *cli_service.TCancelOperationResp, _err error)
-	fCloseOperation        func(ctx context.Context, req *cli_service.TCloseOperationReq) (_r *cli_service.TCloseOperationResp, _err error)
-	fGetResultSetMetadata  func(ctx context.Context, req *cli_service.TGetResultSetMetadataReq) (_r *cli_service.TGetResultSetMetadataResp, _err error)
-	fFetchResults          func(ctx context.Context, req *cli_service.TFetchResultsReq) (_r *cli_service.TFetchResultsResp, _err error)
-	fGetDelegationToken    func(ctx context.Context, req *cli_service.TGetDelegationTokenReq) (_r *cli_service.TGetDelegationTokenResp, _err error)
-	fCancelDelegationToken func(ctx context.Context, req *cli_service.TCancelDelegationTokenReq) (_r *cli_service.TCancelDelegationTokenResp, _err error)
-	fRenewDelegationToken  func(ctx context.Context, req *cli_service.TRenewDelegationTokenReq) (_r *cli_service.TRenewDelegationTokenResp, _err error)
-}
-
-var _ cli_service.TCLIService = (*rowTestClient)(nil)
-
-func (c *rowTestClient) OpenSession(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error) {
-	if c.fOpenSession != nil {
-		return c.fOpenSession(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) CloseSession(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error) {
-	if c.fCloseSession != nil {
-		return c.fCloseSession(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetInfo(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error) {
-	if c.fGetInfo != nil {
-		return c.fGetInfo(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) ExecuteStatement(ctx context.Context, req *cli_service.TExecuteStatementReq) (_r *cli_service.TExecuteStatementResp, _err error) {
-	if c.fExecuteStatement != nil {
-		return c.fExecuteStatement(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetTypeInfo(ctx context.Context, req *cli_service.TGetTypeInfoReq) (_r *cli_service.TGetTypeInfoResp, _err error) {
-	if c.fGetTypeInfo != nil {
-		return c.fGetTypeInfo(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetCatalogs(ctx context.Context, req *cli_service.TGetCatalogsReq) (_r *cli_service.TGetCatalogsResp, _err error) {
-	if c.fGetCatalogs != nil {
-		return c.fGetCatalogs(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetSchemas(ctx context.Context, req *cli_service.TGetSchemasReq) (_r *cli_service.TGetSchemasResp, _err error) {
-	if c.fGetSchemas != nil {
-		return c.fGetSchemas(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetTables(ctx context.Context, req *cli_service.TGetTablesReq) (_r *cli_service.TGetTablesResp, _err error) {
-	if c.fGetTables != nil {
-		return c.fGetTables(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetTableTypes(ctx context.Context, req *cli_service.TGetTableTypesReq) (_r *cli_service.TGetTableTypesResp, _err error) {
-	if c.fGetTableTypes != nil {
-		return c.fGetTableTypes(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetColumns(ctx context.Context, req *cli_service.TGetColumnsReq) (_r *cli_service.TGetColumnsResp, _err error) {
-	if c.fGetColumns != nil {
-		return c.fGetColumns(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetFunctions(ctx context.Context, req *cli_service.TGetFunctionsReq) (_r *cli_service.TGetFunctionsResp, _err error) {
-	if c.fGetFunctions != nil {
-		return c.fGetFunctions(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetPrimaryKeys(ctx context.Context, req *cli_service.TGetPrimaryKeysReq) (_r *cli_service.TGetPrimaryKeysResp, _err error) {
-	if c.fGetPrimaryKeys != nil {
-		return c.fGetPrimaryKeys(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetCrossReference(ctx context.Context, req *cli_service.TGetCrossReferenceReq) (_r *cli_service.TGetCrossReferenceResp, _err error) {
-	if c.fGetCrossReference != nil {
-		return c.fGetCrossReference(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetOperationStatus(ctx context.Context, req *cli_service.TGetOperationStatusReq) (_r *cli_service.TGetOperationStatusResp, _err error) {
-	if c.fGetOperationStatus != nil {
-		return c.fGetOperationStatus(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) CancelOperation(ctx context.Context, req *cli_service.TCancelOperationReq) (_r *cli_service.TCancelOperationResp, _err error) {
-	if c.fCancelOperation != nil {
-		return c.fCancelOperation(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) CloseOperation(ctx context.Context, req *cli_service.TCloseOperationReq) (_r *cli_service.TCloseOperationResp, _err error) {
-	if c.fCloseOperation != nil {
-		return c.fCloseOperation(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetResultSetMetadata(ctx context.Context, req *cli_service.TGetResultSetMetadataReq) (_r *cli_service.TGetResultSetMetadataResp, _err error) {
-	if c.fGetResultSetMetadata != nil {
-		return c.fGetResultSetMetadata(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) FetchResults(ctx context.Context, req *cli_service.TFetchResultsReq) (_r *cli_service.TFetchResultsResp, _err error) {
-	if c.fFetchResults != nil {
-		return c.fFetchResults(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) GetDelegationToken(ctx context.Context, req *cli_service.TGetDelegationTokenReq) (_r *cli_service.TGetDelegationTokenResp, _err error) {
-	if c.fGetDelegationToken != nil {
-		return c.fGetDelegationToken(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) CancelDelegationToken(ctx context.Context, req *cli_service.TCancelDelegationTokenReq) (_r *cli_service.TCancelDelegationTokenResp, _err error) {
-	if c.fCancelDelegationToken != nil {
-		return c.fCancelDelegationToken(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-func (c *rowTestClient) RenewDelegationToken(ctx context.Context, req *cli_service.TRenewDelegationTokenReq) (_r *cli_service.TRenewDelegationTokenResp, _err error) {
-	if c.fRenewDelegationToken != nil {
-		return c.fRenewDelegationToken(ctx, req)
-	}
-	return nil, ErrNotImplemented
-}
-
 // Build a simple test client
 func getRowsTestSimpleClient(getMetadataCount, fetchResultsCount *int) cli_service.TCLIService {
 	// Metadata for the different types is based on the results returned when querying a table with
@@ -1307,9 +1155,9 @@ func getRowsTestSimpleClient(getMetadataCount, fetchResultsCount *int) cli_servi
 		return pages[pageIndex], nil
 	}
 
-	client := &rowTestClient{
-		fGetResultSetMetadata: getMetadata,
-		fFetchResults:         fetchResults,
+	client := &client.TestClient{
+		FnGetResultSetMetadata: getMetadata,
+		FnFetchResults:         fetchResults,
 	}
 
 	return client


### PR DESCRIPTION
Created unit tests comprehensively covering branching logic for private functions in `connection.go` (`runQuery`, `executeStatement`, `pollOperation`) and connection methods (`ExecContext`, `QueryContext`) 

