### PR TITLE
Increased coverage to statement and connector

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestConnector_Connect(t *testing.T) {
@@ -22,44 +24,46 @@ func TestConnector_Connect(t *testing.T) {
 }
 
 func TestNewConnector(t *testing.T) {
-	//t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {
-	//	host := "databricks-host"
-	//	port := 1
-	//	accessToken := "token"
-	//	httpPath := "http-path"
-	//	maxRows := 100
-	//	timeout := 100
-	//	catalog := "catalog-name"
-	//	schema := "schema-string"
-	//	userAgentEntry := "user-agent"
-	//	sessionParams := map[string]string{"key": "value"}
-	//	connector, err := NewConnector(
-	//		WithServerHostname(host),
-	//		WithPort(port),
-	//		WithAccessToken(accessToken),
-	//		WithHTTPPath(httpPath),
-	//		WithMaxRows(maxRows),
-	//		WithTimeout(timeout),
-	//		WithInitialNamespace(catalog, schema),
-	//		WithUserAgentEntry(userAgentEntry),
-	//		WithSessionParams(sessionParams),
-	//	)
-	//	expectedUserConfig := config.UserConfig{
-	//		Host:                host,
-	//		Port:                port,
-	//		AccessToken:         accessToken,
-	//		HTTPPath:            httpPath,
-	//		MaxRows:             maxRows,
-	//		QueryTimeoutSeconds: timeout,
-	//		Catalog:             catalog,
-	//		Schema:              schema,
-	//		UserAgentEntry:      userAgentEntry,
-	//		SessionParams:       sessionParams,
-	//	}
-	//	expectedCfg := config.WithDefaults()
-	//	expectedCfg.UserConfig = expectedUserConfig
-	//	resultCfg := connector.cfg // ??? something like this possible ??? this doesn't compile
-	//	assert.Nil(t, err)
-	//	assert.Equal(t, expectedCfg, resultCfg)
-	//})
+	t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {
+		host := "databricks-host"
+		port := 1
+		accessToken := "token"
+		httpPath := "http-path"
+		maxRows := 100
+		timeout := 100 * time.Second
+		catalog := "catalog-name"
+		schema := "schema-string"
+		userAgentEntry := "user-agent"
+		sessionParams := map[string]string{"key": "value"}
+		con, err := NewConnector(
+			WithServerHostname(host),
+			WithPort(port),
+			WithAccessToken(accessToken),
+			WithHTTPPath(httpPath),
+			WithMaxRows(maxRows),
+			WithTimeout(timeout),
+			WithInitialNamespace(catalog, schema),
+			WithUserAgentEntry(userAgentEntry),
+			WithSessionParams(sessionParams),
+		)
+		expectedUserConfig := config.UserConfig{
+			Host:           host,
+			Port:           port,
+			Protocol:       "https",
+			AccessToken:    accessToken,
+			HTTPPath:       httpPath,
+			MaxRows:        maxRows,
+			QueryTimeout:   timeout,
+			Catalog:        catalog,
+			Schema:         schema,
+			UserAgentEntry: userAgentEntry,
+			SessionParams:  sessionParams,
+		}
+		expectedCfg := config.WithDefaults()
+		expectedCfg.UserConfig = expectedUserConfig
+		coni, ok := con.(*connector)
+		require.True(t, ok)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedCfg, coni.cfg)
+	})
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,65 @@
+package dbsql
+
+import (
+	"context"
+	"github.com/databricks/databricks-sql-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConnector_Connect(t *testing.T) {
+	t.Run("Connect returns err when thrift client initialization fails", func(t *testing.T) {
+		cfg := config.WithDefaults()
+		cfg.ThriftProtocol = "invalidprotocol"
+
+		testConnector := connector{
+			cfg: cfg,
+		}
+		conn, err := testConnector.Connect(context.Background())
+		assert.Nil(t, conn)
+		assert.Error(t, err)
+	})
+}
+
+func TestNewConnector(t *testing.T) {
+	//t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {
+	//	host := "databricks-host"
+	//	port := 1
+	//	accessToken := "token"
+	//	httpPath := "http-path"
+	//	maxRows := 100
+	//	timeout := 100
+	//	catalog := "catalog-name"
+	//	schema := "schema-string"
+	//	userAgentEntry := "user-agent"
+	//	sessionParams := map[string]string{"key": "value"}
+	//	connector, err := NewConnector(
+	//		WithServerHostname(host),
+	//		WithPort(port),
+	//		WithAccessToken(accessToken),
+	//		WithHTTPPath(httpPath),
+	//		WithMaxRows(maxRows),
+	//		WithTimeout(timeout),
+	//		WithInitialNamespace(catalog, schema),
+	//		WithUserAgentEntry(userAgentEntry),
+	//		WithSessionParams(sessionParams),
+	//	)
+	//	expectedUserConfig := config.UserConfig{
+	//		Host:                host,
+	//		Port:                port,
+	//		AccessToken:         accessToken,
+	//		HTTPPath:            httpPath,
+	//		MaxRows:             maxRows,
+	//		QueryTimeoutSeconds: timeout,
+	//		Catalog:             catalog,
+	//		Schema:              schema,
+	//		UserAgentEntry:      userAgentEntry,
+	//		SessionParams:       sessionParams,
+	//	}
+	//	expectedCfg := config.WithDefaults()
+	//	expectedCfg.UserConfig = expectedUserConfig
+	//	resultCfg := connector.cfg // ??? something like this possible ??? this doesn't compile
+	//	assert.Nil(t, err)
+	//	assert.Equal(t, expectedCfg, resultCfg)
+	//})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,7 +119,7 @@ func (ucfg UserConfig) DeepCopy() UserConfig {
 }
 
 func (ucfg UserConfig) WithDefaults() UserConfig {
-	if ucfg.MaxRows == 0 {
+	if ucfg.MaxRows <= 0 {
 		ucfg.MaxRows = 10000
 	}
 	if ucfg.Protocol == "" {

--- a/rows_test.go
+++ b/rows_test.go
@@ -481,6 +481,7 @@ func TestColumnsWithDirectResults(t *testing.T) {
 	var getMetadataCount, fetchResultsCount int
 
 	rowSet := &rows{}
+	defer rowSet.Close()
 	client := getRowsTestSimpleClient(&getMetadataCount, &fetchResultsCount)
 
 	req := &cli_service.TFetchResultsReq{
@@ -755,6 +756,47 @@ func TestColumnTypeLength(t *testing.T) {
 			assert.False(t, ok)
 		}
 	}
+}
+
+func TestColumnTypeDatabaseTypeName(t *testing.T) {
+	var getMetadataCount, fetchResultsCount int
+
+	rowSet := &rows{}
+	client := getRowsTestSimpleClient(&getMetadataCount, &fetchResultsCount)
+	rowSet.client = client
+
+	resp, err := rowSet.getResultMetadata()
+	assert.Nil(t, err)
+
+	cols := resp.Schema.Columns
+	expectedScanTypes := []reflect.Type{
+		scanTypeBoolean,
+		scanTypeInt8,
+		scanTypeInt16,
+		scanTypeInt32,
+		scanTypeInt64,
+		scanTypeFloat32,
+		scanTypeFloat64,
+		scanTypeString,
+		scanTypeDateTime,
+		scanTypeRawBytes,
+		scanTypeRawBytes,
+		scanTypeRawBytes,
+		scanTypeRawBytes,
+		scanTypeRawBytes,
+		scanTypeDateTime,
+		scanTypeString,
+		scanTypeString,
+	}
+
+	assert.Equal(t, len(expectedScanTypes), len(cols))
+
+	scanTypes := make([]reflect.Type, len(cols))
+	for i := range cols {
+		scanTypes[i] = rowSet.ColumnTypeScanType(i)
+	}
+
+	assert.Equal(t, expectedScanTypes, scanTypes)
 }
 
 type rowTestPagingResult struct {

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,0 +1,166 @@
+package dbsql
+
+import (
+	"context"
+	"database/sql/driver"
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	"github.com/databricks/databricks-sql-go/internal/client"
+	"github.com/databricks/databricks-sql-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStmt_Close(t *testing.T) {
+	t.Run("Close is not applicable", func(t *testing.T) {
+		testStmt := stmt{
+			conn:  &conn{},
+			query: "query string",
+		}
+		err := testStmt.Close()
+		assert.Nil(t, err)
+	})
+}
+
+func TestStmt_NumInput(t *testing.T) {
+	t.Run("NumInput is not applicable", func(t *testing.T) {
+		testStmt := stmt{
+			conn:  &conn{},
+			query: "query string",
+		}
+		numInput := testStmt.NumInput()
+		assert.Equal(t, -1, numInput)
+	})
+}
+
+func TestStmt_Exec(t *testing.T) {
+	t.Run("Exec is not implemented", func(t *testing.T) {
+		testStmt := stmt{
+			conn:  &conn{},
+			query: "query string",
+		}
+		res, err := testStmt.Exec([]driver.Value{})
+		assert.Nil(t, res)
+		assert.Error(t, err)
+	})
+}
+
+func TestStmt_Query(t *testing.T) {
+	t.Run("Query is not implemented", func(t *testing.T) {
+		testStmt := stmt{
+			conn:  &conn{},
+			query: "query string",
+		}
+		res, err := testStmt.Query([]driver.Value{})
+		assert.Nil(t, res)
+		assert.Error(t, err)
+	})
+}
+
+func TestStmt_ExecContext(t *testing.T) {
+	t.Run("ExecContext returns number of rows modified when execution is successful", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		var savedQueryString string
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			savedQueryString = req.Statement
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte{1, 2, 3, 4, 2, 23, 4, 2, 3, 2, 3, 4, 4, 223, 34, 54},
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState:  cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+				NumModifiedRows: thrift.Int64Ptr(10),
+			}
+			return getOperationStatusResp, nil
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		testQuery := "insert 10"
+		testStmt := &stmt{
+			conn:  testConn,
+			query: testQuery,
+		}
+		res, err := testStmt.ExecContext(context.Background(), []driver.NamedValue{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		rowsAffected, _ := res.RowsAffected()
+		assert.Equal(t, int64(10), rowsAffected)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, testQuery, savedQueryString)
+	})
+}
+
+func TestStmt_QueryContext(t *testing.T) {
+	t.Run("QueryContext returns rows object upon successful query", func(t *testing.T) {
+		var executeStatementCount, getOperationStatusCount int
+		var savedQueryString string
+		executeStatement := func(ctx context.Context, req *cli_service.TExecuteStatementReq) (r *cli_service.TExecuteStatementResp, err error) {
+			executeStatementCount++
+			savedQueryString = req.Statement
+			executeStatementResp := &cli_service.TExecuteStatementResp{
+				Status: &cli_service.TStatus{
+					StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+				},
+				OperationHandle: &cli_service.TOperationHandle{
+					OperationId: &cli_service.THandleIdentifier{
+						GUID:   []byte{1, 2, 3, 4, 2, 23, 4, 2, 3, 2, 3, 4, 4, 223, 34, 54},
+						Secret: []byte("b"),
+					},
+				},
+			}
+			return executeStatementResp, nil
+		}
+
+		getOperationStatus := func(ctx context.Context, req *cli_service.TGetOperationStatusReq) (r *cli_service.TGetOperationStatusResp, err error) {
+			getOperationStatusCount++
+			getOperationStatusResp := &cli_service.TGetOperationStatusResp{
+				OperationState:  cli_service.TOperationStatePtr(cli_service.TOperationState_FINISHED_STATE),
+				NumModifiedRows: thrift.Int64Ptr(10),
+			}
+			return getOperationStatusResp, nil
+		}
+
+		testClient := &client.TestClient{
+			FnExecuteStatement:   executeStatement,
+			FnGetOperationStatus: getOperationStatus,
+		}
+		testConn := &conn{
+			session: getTestSession(),
+			client:  testClient,
+			cfg:     config.WithDefaults(),
+		}
+		testQuery := "select 1"
+		testStmt := &stmt{
+			conn:  testConn,
+			query: testQuery,
+		}
+		rows, err := testStmt.QueryContext(context.Background(), []driver.NamedValue{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, rows)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, testQuery, savedQueryString)
+	})
+}


### PR DESCRIPTION
Increased coverage via unit tests to 89.1% with tests added for `statement.go`, `connector.go`
 
Signed-off-by: Matthew Kim <11141331+mattdeekay@users.noreply.github.com>