### PR TITLE
Close optimization for Rows

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -140,22 +140,9 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	// hold on to the operation handle
 	opHandle := exStmtResp.OperationHandle
 
-	rows := rows{
-		connId:        c.id,
-		correlationId: corrId,
-		client:        c.client,
-		opHandle:      opHandle,
-		pageSize:      int64(c.cfg.MaxRows),
-		location:      c.cfg.Location,
-	}
+	rows := NewRows(c.id, corrId, c.client, opHandle, int64(c.cfg.MaxRows), c.cfg.Location, exStmtResp.DirectResults)
 
-	if exStmtResp.DirectResults != nil {
-		// return results
-		rows.fetchResults = exStmtResp.DirectResults.ResultSet
-		rows.fetchResultsMetadata = exStmtResp.DirectResults.ResultSetMetadata
-
-	}
-	return &rows, nil
+	return rows, nil
 
 }
 


### PR DESCRIPTION
When a query returns direct results it is possible that all the query result rows are contained therein.  In this case the server can automatically close the operation.  This is indicated by a non-null CloseOperation member in the TSparkDirectResults structure. In this case calls to Rows.Close don't require any interaction with the server as the operation is already closed.
- added a NewRows function and updated connection to use it when creating Rows
- added logic in NewRows to check for an already closed operation
- updated Rows.Close so we don't make a server round trip when not necessary
- added a unit test for the close optimization logic