### PR TITLE
Close operation after executing statement

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -90,6 +90,8 @@ func (c *conn) IsValid() bool {
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	log := logger.WithContext(c.id, driverctx.CorrelationIdFromContext(ctx), "")
 	msg, start := logger.Track("ExecContext")
+	defer log.Duration(msg, start)
+
 	ctx = driverctx.NewContextWithConnId(ctx, c.id)
 	if len(args) > 0 {
 		return nil, errors.New(ErrParametersNotSupported)
@@ -97,14 +99,28 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	exStmtResp, opStatusResp, err := c.runQuery(ctx, query, args)
 
 	if exStmtResp != nil && exStmtResp.OperationHandle != nil {
+		// we have an operation id so update the logger
 		log = logger.WithContext(c.id, driverctx.CorrelationIdFromContext(ctx), client.SprintGuid(exStmtResp.OperationHandle.OperationId.GUID))
+
+		// since we have an operation handle we can close the operation
+		if opStatusResp == nil || opStatusResp.GetOperationState() != cli_service.TOperationState_CLOSED_STATE {
+			_, err1 := c.client.CloseOperation(ctx, &cli_service.TCloseOperationReq{
+				OperationHandle: exStmtResp.OperationHandle,
+			})
+			if err1 != nil {
+				log.Err(err1).Msg("failed to close operation after executing statement")
+			}
+		}
 	}
-	defer log.Duration(msg, start)
 
 	if err != nil {
+		// TODO: are there error situations in which the operation still needs to be closed?
+		// Currently if there is an error we never get back a TExecuteStatementResponse so
+		// can't try to close.
 		log.Err(err).Msgf("databricks: failed to execute query: query %s", query)
 		return nil, wrapErrf(err, "failed to execute query")
 	}
+
 	res := result{AffectedRows: opStatusResp.GetNumModifiedRows()}
 
 	return &res, nil
@@ -261,10 +277,12 @@ func (c *conn) executeStatement(ctx context.Context, query string, args []driver
 	if err != nil {
 		return nil, err
 	}
+
 	exStmtResp, ok := res.(*cli_service.TExecuteStatementResp)
 	if !ok {
 		return exStmtResp, errors.New("databricks: invalid execute statement response")
 	}
+
 	return exStmtResp, err
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -167,6 +167,18 @@ func TestConn_executeStatement(t *testing.T) {
 			assert.Equal(t, 1, executeStatementCount)
 			assert.Equal(t, opTest.closeOperationCount, closeOperationCount)
 		}
+
+		// if the execute statement response contains direct results with a non-nil CloseOperation member
+		// we shouldn't call close
+		closeOperationCount = 0
+		executeStatementCount = 0
+		executeStatementResp.DirectResults.CloseOperation = &cli_service.TCloseOperationResp{}
+		finished := cli_service.TOperationState_FINISHED_STATE
+		executeStatementResp.DirectResults.OperationStatus.OperationState = &finished
+		_, err := testConn.ExecContext(context.Background(), "select 1", []driver.NamedValue{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, 0, closeOperationCount)
 	})
 
 }

--- a/examples/createdrop/main.go
+++ b/examples/createdrop/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	dbsql "github.com/databricks/databricks-sql-go"
+	dbsqlctx "github.com/databricks/databricks-sql-go/driverctx"
+	dbsqllog "github.com/databricks/databricks-sql-go/logger"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	// use this package to set up logging. By default logging level is `warn`. If you want to disable logging, use `disabled`
+	if err := dbsqllog.SetLogLevel("debug"); err != nil {
+		log.Fatal(err)
+	}
+	// sets the logging output. By default it will use os.Stderr. If running in terminal, it will use ConsoleWriter to make it pretty
+	// dbsqllog.SetLogOutput(os.Stdout)
+
+	// this is just to make it easy to load all variables
+	if err := godotenv.Load(); err != nil {
+		log.Fatal(err)
+	}
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// programmatically initializes the connector
+	// another way is to use a DNS. In this case the equivalent DNS would be:
+	// "token:<my_token>@hostname:port/http_path?catalog=hive_metastore&schema=default&timeout=60&maxRows=10&&timezone=America/Sao_Paulo&ANSI_MODE=true"
+	connector, err := dbsql.NewConnector(
+		// minimum configuration
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		//optional configuration
+		dbsql.WithSessionParams(map[string]string{"timezone": "America/Sao_Paulo", "ansi_mode": "true"}),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+		dbsql.WithTimeout(time.Minute), // defaults to no timeout. Global timeout. Any query will be canceled if taking more than this time.
+		dbsql.WithMaxRows(10),          // defaults to 10000
+	)
+	if err != nil {
+		// This will not be a connection error, but a DSN parse error or
+		// another initialization error.
+		log.Fatal(err)
+
+	}
+	// Opening a driver typically will not attempt to connect to the database.
+	db := sql.OpenDB(connector)
+	// make sure to close it later
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "createdrop-example")
+
+	// sets the timeout to 30 seconds. More than that we ping will fail. The default is 15 seconds
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+
+	// create a table with some data. This has no context timeout, it will follow the timeout of one minute set for the connection.
+	if _, err := db.ExecContext(ogCtx, `CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true)`); err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := db.ExecContext(ogCtx, `DROP TABLE diamonds `); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/workflow/main.go
+++ b/examples/workflow/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"time"
@@ -17,18 +18,18 @@ import (
 func main() {
 	// use this package to set up logging. By default logging level is `warn`. If you want to disable logging, use `disabled`
 	if err := dbsqllog.SetLogLevel("debug"); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	// sets the logging output. By default it will use os.Stderr. If running in terminal, it will use ConsoleWriter to make it pretty
 	// dbsqllog.SetLogOutput(os.Stdout)
 
 	// this is just to make it easy to load all variables
 	if err := godotenv.Load(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// programmatically initializes the connector
@@ -50,7 +51,7 @@ func main() {
 	if err != nil {
 		// This will not be a connection error, but a DSN parse error or
 		// another initialization error.
-		panic(err)
+		log.Fatal(err)
 
 	}
 	// Opening a driver typically will not attempt to connect to the database.
@@ -88,18 +89,18 @@ func main() {
 	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
 	defer cancel()
 	if err := db.PingContext(ctx1); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// create a table with some data. This has no context timeout, it will follow the timeout of one minute set for the connection.
 	if _, err := db.ExecContext(ogCtx, `CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true)`); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// QueryRowContext is a shortcut function to get a single value
 	var max float64
 	if err := db.QueryRowContext(ogCtx, `select max(carat) from diamonds`).Scan(&max); err != nil {
-		panic(err)
+		log.Fatal(err)
 	} else {
 		fmt.Printf("max carat in dataset is: %f\n", max)
 	}
@@ -109,7 +110,7 @@ func main() {
 	defer cancel()
 
 	if rows, err := db.QueryContext(ctx2, "select * from diamonds limit 19"); err != nil {
-		panic(err)
+		log.Fatal(err)
 	} else {
 		type row struct {
 			_c0     int
@@ -127,11 +128,11 @@ func main() {
 
 		cols, err := rows.Columns()
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		types, err := rows.ColumnTypes()
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		for i, c := range cols {
 			fmt.Printf("column %d is %s and has type %v\n", i, c, types[i].DatabaseTypeName())
@@ -141,7 +142,7 @@ func main() {
 			// After row 10 this will cause one fetch call, as 10 rows (maxRows config) will come from the first execute statement call.
 			r := row{}
 			if err := rows.Scan(&r._c0, &r.carat, &r.cut, &r.color, &r.clarity, &r.depth, &r.table, &r.price, &r.x, &r.y, &r.z); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 			res = append(res, r)
 		}
@@ -156,7 +157,7 @@ func main() {
 	var curTimezone string
 
 	if err := db.QueryRowContext(ogCtx, `select current_date(), current_timestamp(), current_timezone()`).Scan(&curDate, &curTimestamp, &curTimezone); err != nil {
-		panic(err)
+		log.Fatal(err)
 	} else {
 		// this will print now at timezone America/Sao_Paulo is: 2022-11-16 20:25:15.282 -0300 -03
 		fmt.Printf("current timestamp at timezone %s is: %s\n", curTimezone, curTimestamp)
@@ -170,11 +171,11 @@ func main() {
 			array_col array < int >,
 			map_col map < string, int >,
 			struct_col struct < string_field string, array_field array < int > >)`); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	var numRows int
 	if err := db.QueryRowContext(ogCtx, `select count(*) from array_map_struct`).Scan(&numRows); err != nil {
-		panic(err)
+		log.Fatal(err)
 	} else {
 		fmt.Printf("table has %d rows\n", numRows)
 	}
@@ -186,7 +187,7 @@ func main() {
 				array(1, 2, 3),
 				map('key1', 1),
 				struct('string_val', array(4, 5, 6)))`); err != nil {
-			panic(err)
+			log.Fatal(err)
 		} else {
 			i, err1 := res.RowsAffected()
 			if err1 != nil {
@@ -197,7 +198,7 @@ func main() {
 	}
 
 	if rows, err := db.QueryContext(ogCtx, "select * from array_map_struct"); err != nil {
-		panic(err)
+		log.Fatal(err)
 	} else {
 		// complex data types are returned as string
 		type row struct {
@@ -208,11 +209,11 @@ func main() {
 		res := []row{}
 		cols, err := rows.Columns()
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		types, err := rows.ColumnTypes()
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		for i, c := range cols {
 			fmt.Printf("column %d is %s and has type %v\n", i, c, types[i].DatabaseTypeName())
@@ -221,7 +222,7 @@ func main() {
 		for rows.Next() {
 			r := row{}
 			if err := rows.Scan(&r.arrayVal, &r.mapVal, &r.structVal); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 			res = append(res, r)
 		}


### PR DESCRIPTION
When executing a query there is a rows object returned to the client and the client is then responsible for closing the row set when finished with it.  
Closing the rows causes the driver to close the operation on the server.

When executing a statement (ex. DROP TABLE ...) the client doesn't receive anything by which they can close the operation.  This results in an operation that is completed but not closed.  Eventually the open operation is closed due to inactivity but the driver should be closing the operation.

- updated connection.ExecContext to close the operation if 1) we receive an operation handle back from the server and 2) the operations status is not already closed.
- added unit test to check that we do/don't close the operation depending on the returned operation status.

Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>