### PR TITLE
Handle parsing negative years in dates

### DIFF
--- a/rows_test.go
+++ b/rows_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -537,8 +539,8 @@ func TestNextNoDirectResults(t *testing.T) {
 	row := make([]driver.Value, len(colNames))
 
 	err = rowSet.Next(row)
-	timestamp, _ := time.Parse(TimestampFormat, "2021-07-01 05:43:28")
-	date, _ := time.Parse(DateFormat, "2021-07-01")
+	timestamp, _ := time.Parse(dateTimeFormats["TIMESTAMP"], "2021-07-01 05:43:28")
+	date, _ := time.Parse(dateTimeFormats["DATE"], "2021-07-01")
 	row0 := []driver.Value{
 		true,
 		driver.Value(nil),
@@ -592,8 +594,8 @@ func TestNextWithDirectResults(t *testing.T) {
 
 	err := rowSet.Next(row)
 
-	timestamp, _ := time.Parse(TimestampFormat, "2021-07-01 05:43:28")
-	date, _ := time.Parse(DateFormat, "2021-07-01")
+	timestamp, _ := time.Parse(dateTimeFormats["TIMESTAMP"], "2021-07-01 05:43:28")
+	date, _ := time.Parse(dateTimeFormats["DATE"], "2021-07-01")
 	row0 := []driver.Value{
 		true,
 		driver.Value(nil),
@@ -619,6 +621,63 @@ func TestNextWithDirectResults(t *testing.T) {
 	assert.Equal(t, int64(1), rowSet.nextRowIndex)
 	assert.Equal(t, 1, getMetadataCount)
 	assert.Equal(t, 1, fetchResultsCount)
+}
+
+func TestHandlingDateTime(t *testing.T) {
+	t.Run("should do nothing if data is not a date/time", func(t *testing.T) {
+		val, err := handleDateTime("this is not a date", "STRING", "string_col", time.UTC)
+		assert.Nil(t, err, "handleDateTime should do nothing if a column is not a date/time")
+		assert.Equal(t, "this is not a date", val)
+	})
+
+	t.Run("should error on invalid date/time value", func(t *testing.T) {
+		_, err := handleDateTime("this is not a date", "DATE", "date_col", time.UTC)
+		assert.NotNil(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), fmt.Sprintf(errRowsParseValue, "DATE", "this is not a date", "date_col")))
+	})
+
+	t.Run("should parse valid date", func(t *testing.T) {
+		dt, err := handleDateTime("2006-12-22", "DATE", "date_col", time.UTC)
+		assert.Nil(t, err)
+		assert.Equal(t, time.Date(2006, 12, 22, 0, 0, 0, 0, time.UTC), dt)
+	})
+
+	t.Run("should parse valid timestamp", func(t *testing.T) {
+		dt, err := handleDateTime("2006-12-22 17:13:11.000001000", "TIMESTAMP", "timestamp_col", time.UTC)
+		assert.Nil(t, err)
+		assert.Equal(t, time.Date(2006, 12, 22, 17, 13, 11, 1000, time.UTC), dt)
+	})
+
+	t.Run("should parse date with negative year", func(t *testing.T) {
+		expectedTime := time.Date(-2006, 12, 22, 0, 0, 0, 0, time.UTC)
+		dateStrings := []string{
+			"-2006-12-22",
+			"\u22122006-12-22",
+			"\x2D2006-12-22",
+		}
+
+		for _, s := range dateStrings {
+			dt, err := handleDateTime(s, "DATE", "date_col", time.UTC)
+			assert.Nil(t, err)
+			assert.Equal(t, expectedTime, dt)
+		}
+	})
+
+	t.Run("should parse timestamp with negative year", func(t *testing.T) {
+		expectedTime := time.Date(-2006, 12, 22, 17, 13, 11, 1000, time.UTC)
+
+		timestampStrings := []string{
+			"-2006-12-22 17:13:11.000001000",
+			"\u22122006-12-22 17:13:11.000001000",
+			"\x2D2006-12-22 17:13:11.000001000",
+		}
+
+		for _, s := range timestampStrings {
+			dt, err := handleDateTime(s, "TIMESTAMP", "timestamp_col", time.UTC)
+			assert.Nil(t, err)
+			assert.Equal(t, expectedTime, dt)
+		}
+	})
 }
 
 func TestGetScanType(t *testing.T) {


### PR DESCRIPTION
time.Time can represent dates with a negative year, however the time.ParseInLocation function does not handle parsing date strings with a negative year.
- Added our own parseInLocation function which handles parsing with negative years.
- Added unit tests for date/time parsing.
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>