### PR TITLE
fix thread safety issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.x (Unreleased)
 
+- Fix thread safety issue in connector
+
 ## 0.2.0 (2022-11-18)
 
 - Support for DirectResults

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,37 +1,13 @@
 package dbsql
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/databricks/databricks-sql-go/internal/cli_service"
-	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestConnector_Connect(t *testing.T) {
-	t.Run("Connect returns err when thrift client initialization fails", func(t *testing.T) {
-		cfg := config.WithDefaults()
-		var openSessionCount int
-		openSession := func(ctx context.Context, req *cli_service.TOpenSessionReq) (r *cli_service.TOpenSessionResp, err error) {
-			openSessionCount++
-			return getTestSession(), nil
-		}
-		testClient := &client.TestClient{
-			FnOpenSession: openSession,
-		}
-		testConnector := connector{
-			cfg:    cfg,
-			client: testClient,
-		}
-		conn, err := testConnector.Connect(context.Background())
-		assert.NotNil(t, conn)
-		assert.NoError(t, err)
-	})
-}
 
 func TestNewConnector(t *testing.T) {
 	t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {

--- a/driver.go
+++ b/driver.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 
-	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	_ "github.com/databricks/databricks-sql-go/logger"
 )
@@ -36,11 +35,8 @@ func (d *databricksDriver) OpenConnector(dsn string) (driver.Connector, error) {
 		return nil, err
 	}
 	cfg.UserConfig = ucfg
-	tclient, err := client.InitThriftClient(cfg)
-	if err != nil {
-		return nil, wrapErr(err, "error initializing thrift client")
-	}
-	return &connector{cfg, tclient}, nil
+
+	return &connector{cfg: cfg}, nil
 }
 
 var _ driver.Driver = (*databricksDriver)(nil)


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/databricks/databricks-sql-go/pull/74).
* __->__ #74

fix thread safety issue

This fixes a thread safety (and structural issue) with connector. Because connectors have a long lifetime (potentially process-lifetime), and are used by multiple threads it's not safe to share the same thrift client connection.

This changes the connector so that a new thrift client is created on each connection. The go DB library will perform pooling of connections, so we don't need to worry about it here.

Signed-off-by: Carl Verge <carl.verge@databricks.com>

