### PR TITLE
Set default port to 443

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -52,4 +52,32 @@ func TestNewConnector(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedCfg, coni.cfg)
 	})
+	t.Run("Connector initialized minimal settings", func(t *testing.T) {
+		host := "databricks-host"
+		port := 443
+		accessToken := "token"
+		httpPath := "http-path"
+		maxRows := 100000
+		sessionParams := map[string]string{}
+		con, err := NewConnector(
+			WithServerHostname(host),
+			WithAccessToken(accessToken),
+			WithHTTPPath(httpPath),
+		)
+		expectedUserConfig := config.UserConfig{
+			Host:          host,
+			Port:          port,
+			Protocol:      "https",
+			AccessToken:   accessToken,
+			HTTPPath:      "/" + httpPath,
+			MaxRows:       maxRows,
+			SessionParams: sessionParams,
+		}
+		expectedCfg := config.WithDefaults()
+		expectedCfg.UserConfig = expectedUserConfig
+		coni, ok := con.(*connector)
+		require.True(t, ok)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedCfg, coni.cfg)
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,10 @@ func (ucfg UserConfig) WithDefaults() UserConfig {
 	}
 	if ucfg.Protocol == "" {
 		ucfg.Protocol = "https"
+		ucfg.Port = 443
+	}
+	if ucfg.Port == 0 {
+		ucfg.Port = 443
 	}
 	ucfg.SessionParams = make(map[string]string)
 	return ucfg


### PR DESCRIPTION
For https connections (the case in production), we always use port 443, so set that as default.

Signed-off-by: Andre Furlan <andre.furlan@databricks.com>