### PR TITLE
Fixing cancel race condition

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,5 +65,8 @@ jobs:
         env:
           CGO_ENABLED: 0
 
+      - name: Test-Race
+        run: make test-race
+
       - name: Build
         run: make linux

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ test: bin/gotestsum  ## Run the go unit tests.
 	@echo "INFO: Running all go unit tests."
 	CGO_ENABLED=0 ./bin/gotestsum --format pkgname-and-test-fails --junitfile $(TEST_RESULTS_DIR)/unit-tests.xml ./...
 
+.PHONY: test-race
+test-race:
+	@echo "INFO: Running all go unit tests."
+	go test -race
+
+
 .PHONY: coverage
 coverage: bin/gotestsum  ## Report the unit test code coverage.
 	@echo "INFO: Generating unit test coverage report."

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: bin/gotestsum  ## Run the go unit tests.
 
 .PHONY: test-race
 test-race:
-	@echo "INFO: Running all go unit tests."
+	@echo "INFO: Running all go unit tests checking for race conditions."
 	go test -race
 
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -544,7 +544,6 @@ func TestConn_pollOperation(t *testing.T) {
 				Secret: []byte("b"),
 			},
 		})
-		time.Sleep(50 * time.Millisecond)
 		assert.Error(t, err)
 		assert.Equal(t, 0, getOperationStatusCount)
 		assert.Equal(t, 1, cancelOperationCount)
@@ -590,7 +589,7 @@ func TestConn_pollOperation(t *testing.T) {
 				Secret: []byte("b"),
 			},
 		})
-		time.Sleep(50 * time.Millisecond)
+
 		assert.Error(t, err)
 		assert.GreaterOrEqual(t, getOperationStatusCount, 1)
 		assert.Equal(t, 1, cancelOperationCount)
@@ -1183,7 +1182,6 @@ func TestConn_ExecContext(t *testing.T) {
 		ctx, cancel = context.WithCancel(ctx)
 		defer cancel()
 		res, err := testConn.ExecContext(ctx, "insert 10", []driver.NamedValue{})
-		time.Sleep(10 * time.Millisecond)
 		assert.Error(t, err)
 		assert.Nil(t, res)
 		assert.Equal(t, 1, executeStatementCount)

--- a/driver_e2e_test.go
+++ b/driver_e2e_test.go
@@ -291,7 +291,6 @@ func TestContextTimeoutExample(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, state.executeStatementCalls)
 	assert.GreaterOrEqual(t, state.getOperationStatusCalls, 1)
-	time.Sleep(time.Second)
 	assert.Equal(t, 1, state.cancelOperationCalls)
 
 }

--- a/internal/sentinel/sentinel_test.go
+++ b/internal/sentinel/sentinel_test.go
@@ -98,7 +98,6 @@ func TestWatch(t *testing.T) {
 			},
 		}
 		status, res, err := s.Watch(context.Background(), 0, 100*time.Millisecond)
-		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, WatchTimeout, status)
 		assert.Equal(t, 1, cancelFnCalls)
 		assert.Nil(t, res)
@@ -167,7 +166,6 @@ func TestWatch(t *testing.T) {
 		}
 		status, res, err := s.Watch(ctx, 0, 15*time.Second)
 		assert.Equal(t, WatchCanceled, status)
-		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, cancelFnCalls, 1)
 		assert.Nil(t, res)
 		assert.Error(t, err)
@@ -194,7 +192,6 @@ func TestWatch(t *testing.T) {
 		}
 		status, res, err := s.Watch(ctx, 0, 200*time.Millisecond)
 		assert.Equal(t, WatchCanceled, status)
-		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, cancelFnCalls, 1)
 		assert.Nil(t, res)
 		assert.Error(t, err)
@@ -273,7 +270,6 @@ func TestWatch(t *testing.T) {
 			},
 		}
 		status, res, err := s.Watch(context.Background(), 0, 0)
-		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, WatchErr, status)
 		assert.Equal(t, 1, statusFnCalls)
 		assert.Nil(t, res)


### PR DESCRIPTION
Because we were spanning a new coroutine to cancel the request, the connection was closing and in parallel the sentinel was trying to cancel

In http_client the coroutines were racing to closeResponse

This PR fixes the issue and adds a new action to run race condition tests.