### PR TITLE
Error types

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3,6 +3,7 @@ package dbsql
 import (
 	"context"
 	"database/sql/driver"
+	dbsqlerror "github.com/databricks/databricks-sql-go/error"
 	"time"
 
 	"github.com/databricks/databricks-sql-go/driverctx"
@@ -120,7 +121,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	}
 	if err != nil {
 		log.Err(err).Msgf("databricks: failed to execute query: query %s", query)
-		return nil, wrapErrf(err, "failed to execute query")
+		return nil, &dbsqlerror.OperationStatusError{Msg: "failed to execute query", Err: err}
 	}
 
 	res := result{AffectedRows: opStatusResp.GetNumModifiedRows()}
@@ -153,7 +154,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to run query") // To log query we need to redact credentials
-		return nil, wrapErrf(err, "failed to run query")
+		return nil, &dbsqlerror.OperationStatusError{Msg: "failed to run query", Err: err}
 	}
 	// hold on to the operation handle
 	opHandle := exStmtResp.OperationHandle

--- a/connection.go
+++ b/connection.go
@@ -45,19 +45,19 @@ func (c *conn) Close() error {
 
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to close connection")
-		return wrapErr(err, "failed to close connection")
+		return &dbsqlerror.OperationStatusError{Msg: "failed to close connection", Err: err}
 	}
 	return nil
 }
 
 // Not supported in Databricks.
 func (c *conn) Begin() (driver.Tx, error) {
-	return nil, errors.New(ErrTransactionsNotSupported)
+	return nil, &dbsqlerror.RequestError{Msg: ErrTransactionsNotSupported}
 }
 
 // Not supported in Databricks.
 func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return nil, errors.New(ErrTransactionsNotSupported)
+	return nil, &dbsqlerror.RequestError{Msg: ErrTransactionsNotSupported}
 }
 
 // Ping attempts to verify that the server is accessible.
@@ -99,7 +99,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 
 	ctx = driverctx.NewContextWithConnId(ctx, c.id)
 	if len(args) > 0 {
-		return nil, errors.New(ErrParametersNotSupported)
+		return nil, &dbsqlerror.RequestError{Msg: ErrParametersNotSupported}
 	}
 	exStmtResp, opStatusResp, err := c.runQuery(ctx, query, args)
 
@@ -141,7 +141,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 	ctx = driverctx.NewContextWithConnId(ctx, c.id)
 	if len(args) > 0 {
-		return nil, errors.New(ErrParametersNotSupported)
+		return nil, &dbsqlerror.RequestError{Msg: ErrParametersNotSupported}
 	}
 	// first we try to get the results synchronously.
 	// at any point in time that the context is done we must cancel and return

--- a/connection.go
+++ b/connection.go
@@ -45,19 +45,19 @@ func (c *conn) Close() error {
 
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to close connection")
-		return dbsqlerror.NewDatabricksError("failed to close connection", err, "", "", "", "", dbsqlerror.Connection)
+		return dbsqlerror.NewDatabricksError(ctx, "failed to close connection", err, "", dbsqlerror.Connection)
 	}
 	return nil
 }
 
 // Not supported in Databricks.
 func (c *conn) Begin() (driver.Tx, error) {
-	return nil, dbsqlerror.NewDatabricksError(dbsqlerror.ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
+	return nil, dbsqlerror.NewDatabricksError(nil, dbsqlerror.ErrTransactionsNotSupported, nil, "", dbsqlerror.QueryFailure)
 }
 
 // Not supported in Databricks.
 func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return nil, dbsqlerror.NewDatabricksError(dbsqlerror.ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
+	return nil, dbsqlerror.NewDatabricksError(ctx, dbsqlerror.ErrTransactionsNotSupported, nil, "", dbsqlerror.QueryFailure)
 }
 
 // Ping attempts to verify that the server is accessible.

--- a/connection.go
+++ b/connection.go
@@ -122,7 +122,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	}
 	if err != nil {
 		log.Err(err).Msgf("databricks: failed to execute query: query %s", query)
-		return nil, dbsqlerror.NewExecutionError(ctx, dbsqlerror.ErrQueryExecution, err, *opStatusResp.SqlState)
+		return nil, dbsqlerror.NewExecutionError(ctx, dbsqlerror.ErrQueryExecution, err, opStatusResp)
 	}
 
 	res := result{AffectedRows: opStatusResp.GetNumModifiedRows()}
@@ -155,7 +155,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to run query") // To log query we need to redact credentials
-		return nil, dbsqlerror.NewExecutionError(ctx, dbsqlerror.ErrQueryExecution, err, *opStatusResp.SqlState)
+		return nil, dbsqlerror.NewExecutionError(ctx, dbsqlerror.ErrQueryExecution, err, opStatusResp)
 	}
 	// hold on to the operation handle
 	opHandle := exStmtResp.OperationHandle

--- a/connection.go
+++ b/connection.go
@@ -52,12 +52,12 @@ func (c *conn) Close() error {
 
 // Not supported in Databricks.
 func (c *conn) Begin() (driver.Tx, error) {
-	return nil, dbsqlerror.NewDatabricksError(ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
+	return nil, dbsqlerror.NewDatabricksError(dbsqlerror.ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
 }
 
 // Not supported in Databricks.
 func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return nil, dbsqlerror.NewDatabricksError(ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
+	return nil, dbsqlerror.NewDatabricksError(dbsqlerror.ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
 }
 
 // Ping attempts to verify that the server is accessible.

--- a/connection.go
+++ b/connection.go
@@ -105,7 +105,8 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 
 	if exStmtResp != nil && exStmtResp.OperationHandle != nil {
 		// we have an operation id so update the logger
-		log = logger.WithContext(c.id, corrId, client.SprintGuid(exStmtResp.OperationHandle.OperationId.GUID))
+		ctx = driverctx.NewContextWithQueryId(ctx, client.SprintGuid(exStmtResp.OperationHandle.OperationId.GUID))
+		log = logger.WithContext(c.id, corrId, driverctx.QueryIdFromContext(ctx))
 
 		// since we have an operation handle we can close the operation if necessary
 		alreadyClosed := exStmtResp.DirectResults != nil && exStmtResp.DirectResults.CloseOperation != nil
@@ -176,9 +177,10 @@ func (c *conn) runQuery(ctx context.Context, query string, args []driver.NamedVa
 	}
 	opHandle := exStmtResp.OperationHandle
 	if opHandle != nil && opHandle.OperationId != nil {
+		ctx = driverctx.NewContextWithQueryId(ctx, client.SprintGuid(opHandle.OperationId.GUID))
 		log = logger.WithContext(
 			c.id,
-			driverctx.CorrelationIdFromContext(ctx), client.SprintGuid(opHandle.OperationId.GUID),
+			driverctx.CorrelationIdFromContext(ctx), driverctx.QueryIdFromContext(ctx),
 		)
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -52,7 +52,7 @@ func (c *conn) Close() error {
 
 // Not supported in Databricks.
 func (c *conn) Begin() (driver.Tx, error) {
-	return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrNotImplemented, nil)
+	return nil, dbsqlerror.NewDriverError(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
 }
 
 // Not supported in Databricks.
@@ -141,7 +141,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 	ctx = driverctx.NewContextWithConnId(ctx, c.id)
 	if len(args) > 0 {
-		return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrParametersNotSupported, nil)
+		return nil, dbsqlerror.NewDriverError(ctx, dbsqlerror.ErrParametersNotSupported, nil)
 	}
 	// first we try to get the results synchronously.
 	// at any point in time that the context is done we must cancel and return

--- a/connection.go
+++ b/connection.go
@@ -45,19 +45,19 @@ func (c *conn) Close() error {
 
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to close connection")
-		return &dbsqlerror.OperationStatusError{Msg: "failed to close connection", Err: err}
+		return dbsqlerror.NewDatabricksError("failed to close connection", err, "", "", "", "", dbsqlerror.Connection)
 	}
 	return nil
 }
 
 // Not supported in Databricks.
 func (c *conn) Begin() (driver.Tx, error) {
-	return nil, &dbsqlerror.RequestError{Msg: ErrTransactionsNotSupported}
+	return nil, dbsqlerror.NewDatabricksError(ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
 }
 
 // Not supported in Databricks.
 func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return nil, &dbsqlerror.RequestError{Msg: ErrTransactionsNotSupported}
+	return nil, dbsqlerror.NewDatabricksError(ErrTransactionsNotSupported, nil, "", "", "", "", dbsqlerror.QueryFailure)
 }
 
 // Ping attempts to verify that the server is accessible.

--- a/connection_test.go
+++ b/connection_test.go
@@ -161,7 +161,7 @@ func TestConn_executeStatement(t *testing.T) {
 			if opTest.err == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, opTest.err)
+				assert.EqualError(t, err, "databricks: query failure error: failed to execute query: "+opTest.err)
 			}
 			assert.Equal(t, 1, executeStatementCount)
 			assert.Equal(t, opTest.closeOperationCount, closeOperationCount)

--- a/connection_test.go
+++ b/connection_test.go
@@ -161,7 +161,7 @@ func TestConn_executeStatement(t *testing.T) {
 			if opTest.err == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, "databricks: query failure error: failed to execute query: "+opTest.err)
+				assert.EqualError(t, err, "databricks: execution error: failed to execute query: "+opTest.err)
 			}
 			assert.Equal(t, 1, executeStatementCount)
 			assert.Equal(t, opTest.closeOperationCount, closeOperationCount)

--- a/connector.go
+++ b/connector.go
@@ -35,7 +35,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	tclient, err := client.InitThriftClient(c.cfg, c.client)
 	if err != nil {
-		return nil, dbsqlerror.NewConnectionError(ctx, dbsqlerror.ErrThriftClient, err)
+		return nil, dbsqlerror.NewRequestError(ctx, dbsqlerror.ErrThriftClient, err)
 	}
 	protocolVersion := int64(c.cfg.ThriftProtocolVersion)
 	session, err := tclient.OpenSession(ctx, &cli_service.TOpenSessionReq{
@@ -49,7 +49,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	})
 
 	if err != nil {
-		return nil, dbsqlerror.NewConnectionError(ctx, fmt.Sprintf("error connecting: host=%s port=%d, httpPath=%s", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath), err)
+		return nil, dbsqlerror.NewRequestError(ctx, fmt.Sprintf("error connecting: host=%s port=%d, httpPath=%s", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath), err)
 	}
 
 	conn := &conn{
@@ -66,7 +66,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		setStmt := fmt.Sprintf("SET `%s` = `%s`;", k, v)
 		_, err := conn.ExecContext(ctx, setStmt, []driver.NamedValue{})
 		if err != nil {
-			return nil, dbsqlerror.NewQueryFailureError(ctx, fmt.Sprintf("error setting session param: %s", setStmt), err, "") // TODO: add error condition
+			return nil, dbsqlerror.NewExecutionError(ctx, fmt.Sprintf("error setting session param: %s", setStmt), err, "")
 		}
 		log.Info().Msgf("set session parameter: param=%s value=%s", k, v)
 	}

--- a/connector.go
+++ b/connector.go
@@ -66,7 +66,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		setStmt := fmt.Sprintf("SET `%s` = `%s`;", k, v)
 		_, err := conn.ExecContext(ctx, setStmt, []driver.NamedValue{})
 		if err != nil {
-			return nil, dbsqlerror.NewExecutionError(ctx, fmt.Sprintf("error setting session param: %s", setStmt), err, "")
+			return nil, dbsqlerror.NewExecutionError(ctx, fmt.Sprintf("error setting session param: %s", setStmt), err, nil)
 		}
 		log.Info().Msgf("set session parameter: param=%s value=%s", k, v)
 	}

--- a/connector.go
+++ b/connector.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net/http"
+	dbsqlerror "github.com/databricks/databricks-sql-go/error"
 	"strings"
 	"time"
 
@@ -34,7 +35,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	tclient, err := client.InitThriftClient(c.cfg, c.client)
 	if err != nil {
-		return nil, wrapErr(err, "error initializing thrift client")
+		return nil, &dbsqlerror.ConnectionError{Msg: "error initializing thrift client", Err: err}
 	}
 	protocolVersion := int64(c.cfg.ThriftProtocolVersion)
 	session, err := tclient.OpenSession(ctx, &cli_service.TOpenSessionReq{
@@ -48,7 +49,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	})
 
 	if err != nil {
-		return nil, wrapErrf(err, "error connecting: host=%s port=%d, httpPath=%s", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath)
+		return nil, &dbsqlerror.ConnectionError{Msg: fmt.Sprintf("error connecting: host=%s port=%d, httpPath=%s", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath), Err: err}
 	}
 
 	conn := &conn{
@@ -65,7 +66,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		setStmt := fmt.Sprintf("SET `%s` = `%s`;", k, v)
 		_, err := conn.ExecContext(ctx, setStmt, []driver.NamedValue{})
 		if err != nil {
-			return nil, err
+			return nil, wrapErr(err, fmt.Sprintf("error setting session param: %s", setStmt))
 		}
 		log.Info().Msgf("set session parameter: param=%s value=%s", k, v)
 	}

--- a/driver_e2e_test.go
+++ b/driver_e2e_test.go
@@ -280,6 +280,9 @@ func TestContextTimeoutExample(t *testing.T) {
 	ctx1, cancel := context.WithTimeout(ogCtx, 5*time.Second)
 	defer cancel()
 	rows, err := db.QueryContext(ctx1, `SELECT id FROM RANGE(100000000) ORDER BY RANDOM() + 2 asc`)
+	if err, ok := err.(stackTracer); ok {
+		fmt.Printf("Stack trace: %v", err.StackTrace())
+	}
 	require.ErrorContains(t, err, context.DeadlineExceeded.Error())
 	require.Nil(t, rows)
 	_, ok := err.(causer)

--- a/driverctx/ctx.go
+++ b/driverctx/ctx.go
@@ -42,7 +42,12 @@ func ConnIdFromContext(ctx context.Context) string {
 	return connId
 }
 
-// QueryIdFromContext retrieves the connectionId stored in context.
+// NewContextWithQueryId creates a new context with queryId value.
+func NewContextWithQueryId(ctx context.Context, queryId string) context.Context {
+	return context.WithValue(ctx, QueryIdContextKey, queryId)
+}
+
+// QueryIdFromContext retrieves the queryId stored in context.
 func QueryIdFromContext(ctx context.Context) string {
 	queryId, ok := ctx.Value(QueryIdContextKey).(string)
 	if !ok {

--- a/driverctx/ctx.go
+++ b/driverctx/ctx.go
@@ -11,6 +11,7 @@ type contextKey int
 const (
 	CorrelationIdContextKey contextKey = iota
 	ConnIdContextKey
+	QueryIdContextKey
 )
 
 // NewContextWithCorrelationId creates a new context with correlationId value. Used by Logger to populate field corrId.
@@ -39,4 +40,13 @@ func ConnIdFromContext(ctx context.Context) string {
 		return ""
 	}
 	return connId
+}
+
+// QueryIdFromContext retrieves the connectionId stored in context.
+func QueryIdFromContext(ctx context.Context) string {
+	queryId, ok := ctx.Value(QueryIdContextKey).(string)
+	if !ok {
+		return ""
+	}
+	return queryId
 }

--- a/err.go
+++ b/err.go
@@ -4,10 +4,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var ErrNotImplemented = "databricks: not implemented"
-var ErrTransactionsNotSupported = "databricks: transactions are not supported"
-var ErrParametersNotSupported = "databricks: query parameters are not supported"
-
 type stackTracer interface {
 	StackTrace() errors.StackTrace
 }

--- a/error/err.go
+++ b/error/err.go
@@ -1,16 +1,18 @@
 package error
 
 import (
+	"context"
 	"fmt"
+	"github.com/databricks/databricks-sql-go/driverctx"
 	"github.com/pkg/errors"
 )
 
 type DatabricksError struct {
-	msg          string
-	err          error
-	corrId       string
-	connId       string
-	queryId      string
+	msg    string
+	err    error
+	corrId string
+	connId string
+	//queryId      string
 	errCondition string
 	errType      DatabricksErrorType
 }
@@ -59,8 +61,10 @@ const (
 	// Connection error messages
 )
 
-func NewDatabricksError(msg string, err error, corrId string, connId string, queryId string, errCondition string, errType DatabricksErrorType) *DatabricksError {
-	return &DatabricksError{msg, errors.WithStack(err), corrId, connId, queryId, errCondition, errType}
+func NewDatabricksError(ctx context.Context, msg string, err error, errCondition string, errType DatabricksErrorType) *DatabricksError {
+	corrId := driverctx.CorrelationIdFromContext(ctx)
+	connId := driverctx.ConnIdFromContext(ctx)
+	return &DatabricksError{msg, errors.WithStack(err), corrId, connId, errCondition, errType}
 }
 
 func (e *DatabricksError) Error() string {

--- a/error/err.go
+++ b/error/err.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/databricks/databricks-sql-go/driverctx"
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/pkg/errors"
 )
 
@@ -156,8 +157,12 @@ func (q *ExecutionError) SqlState() string {
 	return q.sqlState
 }
 
-func NewExecutionError(ctx context.Context, msg string, err error, sqlState string) *ExecutionError {
+func NewExecutionError(ctx context.Context, msg string, err error, opStatusResp *cli_service.TGetOperationStatusResp) *ExecutionError {
 	dbsqlErr := newDatabricksError(ctx, msg, err, Execution)
 	errClass := ""
+	sqlState := ""
+	if opStatusResp != nil {
+		sqlState = *opStatusResp.SqlState
+	}
 	return &ExecutionError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errClass, sqlState}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -16,6 +16,7 @@ type DatabricksError struct {
 
 type DatabricksErrorType int64
 
+// Error types
 const (
 	Unknown DatabricksErrorType = iota
 	Driver
@@ -40,6 +41,22 @@ func (t DatabricksErrorType) String() string {
 	}
 	return "unknown"
 }
+
+// Error messages
+const (
+	// Driver error messages
+
+	// Authentication error messages
+
+	// QueryFailure error messages
+	ErrNotImplemented           = "not implemented"
+	ErrTransactionsNotSupported = "transactions are not supported"
+	ErrParametersNotSupported   = "query parameters are not supported"
+
+	// Network error messages
+
+	// Connection error messages
+)
 
 func NewDatabricksError(msg string, err error, corrId string, connId string, queryId string, errCondition string, errType DatabricksErrorType) *DatabricksError {
 	return &DatabricksError{msg, err, corrId, connId, queryId, errCondition, errType}

--- a/error/err.go
+++ b/error/err.go
@@ -141,8 +141,8 @@ func NewRequestError(ctx context.Context, msg string, err error) *RequestError {
 type ExecutionError struct {
 	databricksError
 	queryId  string
-	errClass string
-	sqlState string
+	errClass *string
+	sqlState *string
 }
 
 func (q *ExecutionError) QueryId() string {
@@ -150,19 +150,19 @@ func (q *ExecutionError) QueryId() string {
 }
 
 func (q *ExecutionError) ErrorClass() string {
-	return q.errClass
+	return *(q.errClass)
 }
 
 func (q *ExecutionError) SqlState() string {
-	return q.sqlState
+	return *(q.sqlState)
 }
 
 func NewExecutionError(ctx context.Context, msg string, err error, opStatusResp *cli_service.TGetOperationStatusResp) *ExecutionError {
 	dbsqlErr := newDatabricksError(ctx, msg, err, Execution)
-	errClass := ""
-	sqlState := ""
+	errClassPtr := (*string)(nil)
+	sqlStatePtr := (*string)(nil)
 	if opStatusResp != nil {
-		sqlState = *opStatusResp.SqlState
+		sqlStatePtr = opStatusResp.SqlState
 	}
-	return &ExecutionError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errClass, sqlState}
+	return &ExecutionError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errClassPtr, sqlStatePtr}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -13,3 +13,13 @@ type ConnectionError struct {
 func (e *ConnectionError) Error() string {
 	return fmt.Sprintf("databricks: connection error: %s\n%v", e.Msg, e.Err)
 }
+
+// OperationStatusError is returned when query operation moves to an error state
+type OperationStatusError struct {
+	Msg string
+	Err error
+}
+
+func (e *OperationStatusError) Error() string {
+	return fmt.Sprintf("databricks: operation status error: %s\n%v", e.Msg, e.Err)
+}

--- a/error/err.go
+++ b/error/err.go
@@ -7,21 +7,73 @@ import (
 	"github.com/pkg/errors"
 )
 
-type DatabricksError struct {
-	msg    string
-	err    error
-	corrId string
-	connId string
-	//queryId      string
-	errCondition string
-	errType      DatabricksErrorType
+// Error messages
+const (
+	// Driver error messages
+	ErrNotImplemented           = "not implemented"
+	ErrTransactionsNotSupported = "transactions are not supported"
+	ErrParametersNotSupported   = "query parameters are not supported"
+	ErrInvalidOperationState    = "invalid operation state. This should not have happened"
+	ErrReadQueryStatus          = "could not read query status"
+
+	// Authentication error messages
+	ErrNoAuthenticationMethod = "no authentication method set"
+	ErrInvalidDSNFormat       = "invalid DSN: invalid format"
+	ErrInvalidDSNPort         = "invalid DSN: invalid DSN port"
+	ErrInvalidDSNEmptyToken   = "invalid DSN: empty token"
+	ErrBasicAuthNotSupported  = "invalid DSN: basic auth not enabled"
+	ErrInvalidDSNMaxRows      = "invalid DSN: maxRows param is not an integer"
+	ErrInvalidDSNTimeout      = "invalid DSN: timeout param is not an integer"
+
+	// QueryFailure error messages
+	ErrQueryExecution = "failed to execute query"
+
+	// Network error messages
+
+	// Connection error messages
+	ErrCloseConnection = "failed to close connection"
+	ErrThriftClient    = "error initializing thrift client"
+	ErrInvalidURL      = "invalid URL"
+)
+
+type DatabricksError interface {
+	Error() string
+	ErrorType() string
+	CorrelationId() string
+	ConnectionId() string
+	Message() string
+	ErrorCondition() string
 }
 
-type DatabricksErrorType int64
+type databricksError struct {
+	msg     string
+	err     error
+	corrId  string
+	connId  string
+	errType dbsqlErrorType
+}
+
+func newDatabricksError(ctx context.Context, msg string, err error, errType dbsqlErrorType) *databricksError {
+	corrId := ""
+	connId := ""
+	if ctx != nil {
+		corrId = driverctx.CorrelationIdFromContext(ctx)
+		connId = driverctx.ConnIdFromContext(ctx)
+	}
+	return &databricksError{
+		msg:     msg,
+		err:     errors.WithStack(err),
+		corrId:  corrId,
+		connId:  connId,
+		errType: errType,
+	}
+}
+
+type dbsqlErrorType int64
 
 // Error types
 const (
-	Unknown DatabricksErrorType = iota
+	Unknown dbsqlErrorType = iota
 	Driver
 	Authentication
 	QueryFailure
@@ -29,7 +81,7 @@ const (
 	Connection
 )
 
-func (t DatabricksErrorType) String() string {
+func (t dbsqlErrorType) string() string {
 	switch t {
 	case Driver:
 		return "driver"
@@ -45,56 +97,78 @@ func (t DatabricksErrorType) String() string {
 	return "unknown"
 }
 
-// Error messages
-const (
-	// Driver error messages
-
-	// Authentication error messages
-
-	// QueryFailure error messages
-	ErrNotImplemented           = "not implemented"
-	ErrTransactionsNotSupported = "transactions are not supported"
-	ErrParametersNotSupported   = "query parameters are not supported"
-
-	// Network error messages
-
-	// Connection error messages
-)
-
-func NewDatabricksError(ctx context.Context, msg string, err error, errCondition string, errType DatabricksErrorType) *DatabricksError {
-	corrId := driverctx.CorrelationIdFromContext(ctx)
-	connId := driverctx.ConnIdFromContext(ctx)
-	return &DatabricksError{msg, errors.WithStack(err), corrId, connId, errCondition, errType}
+type DatabricksErrorWithQuery interface {
+	QueryId() string
+	ErrorCondition() string
 }
 
-func (e *DatabricksError) Error() string {
-	return fmt.Sprintf("databricks: %s error: %s\n%v", e.errType.String(), e.msg, e.err)
+func (e *databricksError) Error() string {
+	return fmt.Sprintf("databricks: %s error: %s: %v", e.errType.string(), e.msg, e.err)
 }
 
-func (e *DatabricksError) Unwrap() error {
+func (e *databricksError) Unwrap() error {
 	return e.err
 }
 
-func (e *DatabricksError) Message() string {
+func (e *databricksError) Message() string {
 	return e.msg
 }
 
-func (e *DatabricksError) CorrelationId() string {
+func (e *databricksError) CorrelationId() string {
 	return e.corrId
 }
 
-func (e *DatabricksError) ConnectionId() string {
+func (e *databricksError) ConnectionId() string {
 	return e.connId
 }
 
-func (e *DatabricksError) QueryId() string {
-	return e.queryId
+func (e *databricksError) ErrorType() string {
+	return e.errType.string()
 }
 
-func (e *DatabricksError) ErrorCondition() string {
-	return e.errCondition
+// DriverError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
+type DriverError struct {
+	*databricksError
 }
 
-func (e *DatabricksError) ErrorType() string {
-	return e.errType.String()
+func NewDriverError(ctx context.Context, msg string, err error) DriverError {
+	return DriverError{newDatabricksError(ctx, msg, err, Driver)}
+}
+
+// AuthenticationError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
+type AuthenticationError struct {
+	*databricksError
+}
+
+func NewAuthenticationError(ctx context.Context, msg string, err error) AuthenticationError {
+	return AuthenticationError{newDatabricksError(ctx, msg, err, Driver)}
+}
+
+// QueryFailureError are errors with the query such as invalid syntax, etc
+type QueryFailureError struct {
+	*databricksError
+	queryId      string
+	errCondition string
+}
+
+func (q *QueryFailureError) QueryId() string {
+	return q.queryId
+}
+
+func (q *QueryFailureError) ErrorCondition() string {
+	return q.errCondition
+}
+
+func NewQueryFailureError(ctx context.Context, msg string, err error, errCondition string) QueryFailureError {
+	dbsqlErr := newDatabricksError(ctx, msg, err, QueryFailure)
+	return QueryFailureError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errCondition}
+}
+
+// ConnectionError are issues with the connection
+type ConnectionError struct {
+	*databricksError
+}
+
+func NewConnectionError(ctx context.Context, msg string, err error) DriverError {
+	return DriverError{newDatabricksError(ctx, msg, err, Driver)}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -28,7 +28,7 @@ const (
 	ErrNoAuthenticationMethod = "no authentication method set"
 	ErrInvalidDSNFormat       = "invalid DSN: invalid format"
 	ErrInvalidDSNPort         = "invalid DSN: invalid DSN port"
-	ErrInvalidDSNTokenIsEmpty = "invalid DSN: empty token"
+	ErrInvalidDSNPATIsEmpty   = "invalid DSN: empty token"
 	ErrBasicAuthNotSupported  = "invalid DSN: basic auth not enabled"
 	ErrInvalidDSNMaxRows      = "invalid DSN: maxRows param is not an integer"
 	ErrInvalidDSNTimeout      = "invalid DSN: timeout param is not an integer"

--- a/error/err.go
+++ b/error/err.go
@@ -11,20 +11,21 @@ type DatabricksError struct {
 	connId       string
 	queryId      string
 	errCondition string
-	errType      databricksErrorType
+	errType      DatabricksErrorType
 }
 
-type databricksErrorType int64
+type DatabricksErrorType int64
 
 const (
-	Unknown databricksErrorType = iota
+	Unknown DatabricksErrorType = iota
 	Driver
 	Authentication
 	QueryFailure
 	Network
+	Connection
 )
 
-func (t databricksErrorType) String() string {
+func (t DatabricksErrorType) String() string {
 	switch t {
 	case Driver:
 		return "driver"
@@ -34,8 +35,14 @@ func (t databricksErrorType) String() string {
 		return "query failure"
 	case Network:
 		return "network"
+	case Connection:
+		return "connection"
 	}
 	return "unknown"
+}
+
+func NewDatabricksError(msg string, err error, corrId string, connId string, queryId string, errCondition string, errType DatabricksErrorType) *DatabricksError {
+	return &DatabricksError{msg, err, corrId, connId, queryId, errCondition, errType}
 }
 
 func (e *DatabricksError) Error() string {

--- a/error/err.go
+++ b/error/err.go
@@ -53,8 +53,8 @@ type databricksError struct {
 	errType dbsqlErrorType
 }
 
-func newDatabricksError(ctx context.Context, msg string, err error, errType dbsqlErrorType) *databricksError {
-	return &databricksError{
+func newDatabricksError(ctx context.Context, msg string, err error, errType dbsqlErrorType) databricksError {
+	return databricksError{
 		msg:     msg,
 		err:     errors.WithStack(err),
 		corrId:  driverctx.CorrelationIdFromContext(ctx),
@@ -96,33 +96,33 @@ type DatabricksErrorWithQuery interface {
 	ErrorCondition() string
 }
 
-func (e *databricksError) Error() string {
+func (e databricksError) Error() string {
 	return fmt.Sprintf("databricks: %s error: %s: %v", e.errType.string(), e.msg, e.err)
 }
 
-func (e *databricksError) Unwrap() error {
+func (e databricksError) Unwrap() error {
 	return e.err
 }
 
-func (e *databricksError) Message() string {
+func (e databricksError) Message() string {
 	return e.msg
 }
 
-func (e *databricksError) CorrelationId() string {
+func (e databricksError) CorrelationId() string {
 	return e.corrId
 }
 
-func (e *databricksError) ConnectionId() string {
+func (e databricksError) ConnectionId() string {
 	return e.connId
 }
 
-func (e *databricksError) ErrorType() string {
+func (e databricksError) ErrorType() string {
 	return e.errType.string()
 }
 
 // DriverError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
 type DriverError struct {
-	*databricksError
+	databricksError
 }
 
 func NewDriverError(ctx context.Context, msg string, err error) DriverError {
@@ -131,7 +131,7 @@ func NewDriverError(ctx context.Context, msg string, err error) DriverError {
 
 // AuthenticationError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
 type AuthenticationError struct {
-	*databricksError
+	databricksError
 }
 
 func NewAuthenticationError(ctx context.Context, msg string, err error) AuthenticationError {
@@ -140,16 +140,16 @@ func NewAuthenticationError(ctx context.Context, msg string, err error) Authenti
 
 // QueryFailureError are errors with the query such as invalid syntax, etc
 type QueryFailureError struct {
-	*databricksError
+	databricksError
 	queryId      string
 	errCondition string
 }
 
-func (q *QueryFailureError) QueryId() string {
+func (q QueryFailureError) QueryId() string {
 	return q.queryId
 }
 
-func (q *QueryFailureError) ErrorCondition() string {
+func (q QueryFailureError) ErrorCondition() string {
 	return q.errCondition
 }
 
@@ -160,7 +160,7 @@ func NewQueryFailureError(ctx context.Context, msg string, err error, errConditi
 
 // ConnectionError are issues with the connection
 type ConnectionError struct {
-	*databricksError
+	databricksError
 }
 
 func NewConnectionError(ctx context.Context, msg string, err error) DriverError {

--- a/error/err.go
+++ b/error/err.go
@@ -9,14 +9,22 @@ import (
 
 // Error messages
 const (
-	// Driver error messages
+	// System Fault (driver errors, system failures)
 	ErrNotImplemented           = "not implemented"
 	ErrTransactionsNotSupported = "transactions are not supported"
 	ErrParametersNotSupported   = "query parameters are not supported"
 	ErrInvalidOperationState    = "invalid operation state. This should not have happened"
-	ErrReadQueryStatus          = "could not read query status"
 
-	// Authentication error messages
+	ErrReadQueryStatus = "could not read query status"
+
+	// Execution error messages (query failure)
+	ErrQueryExecution = "failed to execute query"
+
+	// Request error messages (connection, authentication, network error)
+	ErrCloseConnection = "failed to close connection"
+	ErrThriftClient    = "error initializing thrift client"
+	ErrInvalidURL      = "invalid URL"
+
 	ErrNoAuthenticationMethod = "no authentication method set"
 	ErrInvalidDSNFormat       = "invalid DSN: invalid format"
 	ErrInvalidDSNPort         = "invalid DSN: invalid DSN port"
@@ -24,16 +32,6 @@ const (
 	ErrBasicAuthNotSupported  = "invalid DSN: basic auth not enabled"
 	ErrInvalidDSNMaxRows      = "invalid DSN: maxRows param is not an integer"
 	ErrInvalidDSNTimeout      = "invalid DSN: timeout param is not an integer"
-
-	// QueryFailure error messages
-	ErrQueryExecution = "failed to execute query"
-
-	// Network error messages
-
-	// Connection error messages
-	ErrCloseConnection = "failed to close connection"
-	ErrThriftClient    = "error initializing thrift client"
-	ErrInvalidURL      = "invalid URL"
 )
 
 type DatabricksError interface {
@@ -68,25 +66,19 @@ type dbsqlErrorType int64
 // Error types
 const (
 	Unknown dbsqlErrorType = iota
-	Driver
-	Authentication
-	QueryFailure
-	Network
-	Connection
+	Request
+	Execution
+	System
 )
 
 func (t dbsqlErrorType) string() string {
 	switch t {
-	case Driver:
-		return "driver"
-	case Authentication:
-		return "authentication"
-	case QueryFailure:
-		return "query failure"
-	case Network:
-		return "network"
-	case Connection:
-		return "connection"
+	case Request:
+		return "request error"
+	case Execution:
+		return "execution error"
+	case System:
+		return "system fault"
 	}
 	return "unknown"
 }
@@ -97,7 +89,7 @@ type DatabricksErrorWithQuery interface {
 }
 
 func (e databricksError) Error() string {
-	return fmt.Sprintf("databricks: %s error: %s: %v", e.errType.string(), e.msg, e.err)
+	return fmt.Sprintf("databricks: %s: %s: %v", e.errType.string(), e.msg, e.err)
 }
 
 func (e databricksError) Unwrap() error {
@@ -120,49 +112,52 @@ func (e databricksError) ErrorType() string {
 	return e.errType.string()
 }
 
-// DriverError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
-type DriverError struct {
+// SystemFault are issues with the driver or server, e.g. not supported operations, driver specific non-recoverable failures
+type SystemFault struct {
+	databricksError
+	isRetryable bool
+}
+
+func (e *SystemFault) IsRetryable() bool {
+	return e.isRetryable
+}
+
+func NewSystemFault(ctx context.Context, msg string, err error) *SystemFault {
+	dbsqlErr := newDatabricksError(ctx, msg, err, System)
+	return &SystemFault{dbsqlErr, false}
+}
+
+// RequestError are errors caused by invalid requests, e.g. permission denied, warehouse not found
+type RequestError struct {
 	databricksError
 }
 
-func NewDriverError(ctx context.Context, msg string, err error) *DriverError {
-	return &DriverError{newDatabricksError(ctx, msg, err, Driver)}
+func NewRequestError(ctx context.Context, msg string, err error) *RequestError {
+	return &RequestError{newDatabricksError(ctx, msg, err, Request)}
 }
 
-// AuthenticationError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
-type AuthenticationError struct {
+// ExecutionError are errors occurring after the query has been submitted, e.g. invalid syntax, query timeout
+type ExecutionError struct {
 	databricksError
+	queryId  string
+	errClass string
+	sqlState string
 }
 
-func NewAuthenticationError(ctx context.Context, msg string, err error) *AuthenticationError {
-	return &AuthenticationError{newDatabricksError(ctx, msg, err, Authentication)}
-}
-
-// QueryFailureError are errors with the query such as invalid syntax, etc
-type QueryFailureError struct {
-	databricksError
-	queryId      string
-	errCondition string
-}
-
-func (q *QueryFailureError) QueryId() string {
+func (q *ExecutionError) QueryId() string {
 	return q.queryId
 }
 
-func (q *QueryFailureError) ErrorCondition() string {
-	return q.errCondition
+func (q *ExecutionError) ErrorClass() string {
+	return q.errClass
 }
 
-func NewQueryFailureError(ctx context.Context, msg string, err error, errCondition string) *QueryFailureError {
-	dbsqlErr := newDatabricksError(ctx, msg, err, QueryFailure)
-	return &QueryFailureError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errCondition}
+func (q *ExecutionError) SqlState() string {
+	return q.sqlState
 }
 
-// ConnectionError are issues with the connection
-type ConnectionError struct {
-	databricksError
-}
-
-func NewConnectionError(ctx context.Context, msg string, err error) *ConnectionError {
-	return &ConnectionError{newDatabricksError(ctx, msg, err, Connection)}
+func NewExecutionError(ctx context.Context, msg string, err error, sqlState string) *ExecutionError {
+	dbsqlErr := newDatabricksError(ctx, msg, err, Execution)
+	errClass := ""
+	return &ExecutionError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errClass, sqlState}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -20,7 +20,7 @@ const (
 	ErrNoAuthenticationMethod = "no authentication method set"
 	ErrInvalidDSNFormat       = "invalid DSN: invalid format"
 	ErrInvalidDSNPort         = "invalid DSN: invalid DSN port"
-	ErrInvalidDSNEmptyToken   = "invalid DSN: empty token"
+	ErrInvalidDSNTokenIsEmpty = "invalid DSN: empty token"
 	ErrBasicAuthNotSupported  = "invalid DSN: basic auth not enabled"
 	ErrInvalidDSNMaxRows      = "invalid DSN: maxRows param is not an integer"
 	ErrInvalidDSNTimeout      = "invalid DSN: timeout param is not an integer"
@@ -54,17 +54,11 @@ type databricksError struct {
 }
 
 func newDatabricksError(ctx context.Context, msg string, err error, errType dbsqlErrorType) *databricksError {
-	corrId := ""
-	connId := ""
-	if ctx != nil {
-		corrId = driverctx.CorrelationIdFromContext(ctx)
-		connId = driverctx.ConnIdFromContext(ctx)
-	}
 	return &databricksError{
 		msg:     msg,
 		err:     errors.WithStack(err),
-		corrId:  corrId,
-		connId:  connId,
+		corrId:  driverctx.CorrelationIdFromContext(ctx),
+		connId:  driverctx.ConnIdFromContext(ctx),
 		errType: errType,
 	}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -23,3 +23,13 @@ type OperationStatusError struct {
 func (e *OperationStatusError) Error() string {
 	return fmt.Sprintf("databricks: operation status error: %s\n%v", e.Msg, e.Err)
 }
+
+// RequestError is an error with the client's request
+type RequestError struct {
+	Msg string
+	Err error
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf("databricks: request error: %s\n%v", e.Msg, e.Err)
+}

--- a/error/err.go
+++ b/error/err.go
@@ -1,6 +1,8 @@
 package error
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // ConnectionError is an error in the connection to the server
 type ConnectionError struct {

--- a/error/err.go
+++ b/error/err.go
@@ -135,7 +135,7 @@ type AuthenticationError struct {
 }
 
 func NewAuthenticationError(ctx context.Context, msg string, err error) *AuthenticationError {
-	return &AuthenticationError{newDatabricksError(ctx, msg, err, Driver)}
+	return &AuthenticationError{newDatabricksError(ctx, msg, err, Authentication)}
 }
 
 // QueryFailureError are errors with the query such as invalid syntax, etc
@@ -163,6 +163,6 @@ type ConnectionError struct {
 	databricksError
 }
 
-func NewConnectionError(ctx context.Context, msg string, err error) *DriverError {
-	return &DriverError{newDatabricksError(ctx, msg, err, Driver)}
+func NewConnectionError(ctx context.Context, msg string, err error) *ConnectionError {
+	return &ConnectionError{newDatabricksError(ctx, msg, err, Connection)}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -2,6 +2,7 @@ package error
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 )
 
 type DatabricksError struct {
@@ -59,7 +60,7 @@ const (
 )
 
 func NewDatabricksError(msg string, err error, corrId string, connId string, queryId string, errCondition string, errType DatabricksErrorType) *DatabricksError {
-	return &DatabricksError{msg, err, corrId, connId, queryId, errCondition, errType}
+	return &DatabricksError{msg, errors.WithStack(err), corrId, connId, queryId, errCondition, errType}
 }
 
 func (e *DatabricksError) Error() string {

--- a/error/err.go
+++ b/error/err.go
@@ -1,0 +1,13 @@
+package error
+
+import "fmt"
+
+// ConnectionError is an error in the connection to the server
+type ConnectionError struct {
+	Msg string
+	Err error
+}
+
+func (e *ConnectionError) Error() string {
+	return fmt.Sprintf("databricks: connection error: %s\n%v", e.Msg, e.Err)
+}

--- a/error/err.go
+++ b/error/err.go
@@ -125,8 +125,8 @@ type DriverError struct {
 	databricksError
 }
 
-func NewDriverError(ctx context.Context, msg string, err error) DriverError {
-	return DriverError{newDatabricksError(ctx, msg, err, Driver)}
+func NewDriverError(ctx context.Context, msg string, err error) *DriverError {
+	return &DriverError{newDatabricksError(ctx, msg, err, Driver)}
 }
 
 // AuthenticationError are issues with the driver, e.g. not supported operations, driver specific non-recoverable failures
@@ -134,8 +134,8 @@ type AuthenticationError struct {
 	databricksError
 }
 
-func NewAuthenticationError(ctx context.Context, msg string, err error) AuthenticationError {
-	return AuthenticationError{newDatabricksError(ctx, msg, err, Driver)}
+func NewAuthenticationError(ctx context.Context, msg string, err error) *AuthenticationError {
+	return &AuthenticationError{newDatabricksError(ctx, msg, err, Driver)}
 }
 
 // QueryFailureError are errors with the query such as invalid syntax, etc
@@ -145,17 +145,17 @@ type QueryFailureError struct {
 	errCondition string
 }
 
-func (q QueryFailureError) QueryId() string {
+func (q *QueryFailureError) QueryId() string {
 	return q.queryId
 }
 
-func (q QueryFailureError) ErrorCondition() string {
+func (q *QueryFailureError) ErrorCondition() string {
 	return q.errCondition
 }
 
-func NewQueryFailureError(ctx context.Context, msg string, err error, errCondition string) QueryFailureError {
+func NewQueryFailureError(ctx context.Context, msg string, err error, errCondition string) *QueryFailureError {
 	dbsqlErr := newDatabricksError(ctx, msg, err, QueryFailure)
-	return QueryFailureError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errCondition}
+	return &QueryFailureError{dbsqlErr, driverctx.QueryIdFromContext(ctx), errCondition}
 }
 
 // ConnectionError are issues with the connection
@@ -163,6 +163,6 @@ type ConnectionError struct {
 	databricksError
 }
 
-func NewConnectionError(ctx context.Context, msg string, err error) DriverError {
-	return DriverError{newDatabricksError(ctx, msg, err, Driver)}
+func NewConnectionError(ctx context.Context, msg string, err error) *DriverError {
+	return &DriverError{newDatabricksError(ctx, msg, err, Driver)}
 }

--- a/error/err.go
+++ b/error/err.go
@@ -4,32 +4,68 @@ import (
 	"fmt"
 )
 
-// ConnectionError is an error in the connection to the server
-type ConnectionError struct {
-	Msg string
-	Err error
+type DatabricksError struct {
+	msg          string
+	err          error
+	corrId       string
+	connId       string
+	queryId      string
+	errCondition string
+	errType      databricksErrorType
 }
 
-func (e *ConnectionError) Error() string {
-	return fmt.Sprintf("databricks: connection error: %s\n%v", e.Msg, e.Err)
+type databricksErrorType int64
+
+const (
+	Unknown databricksErrorType = iota
+	Driver
+	Authentication
+	QueryFailure
+	Network
+)
+
+func (t databricksErrorType) String() string {
+	switch t {
+	case Driver:
+		return "driver"
+	case Authentication:
+		return "authentication"
+	case QueryFailure:
+		return "query failure"
+	case Network:
+		return "network"
+	}
+	return "unknown"
 }
 
-// OperationStatusError is returned when query operation moves to an error state
-type OperationStatusError struct {
-	Msg string
-	Err error
+func (e *DatabricksError) Error() string {
+	return fmt.Sprintf("databricks: %s error: %s\n%v", e.errType.String(), e.msg, e.err)
 }
 
-func (e *OperationStatusError) Error() string {
-	return fmt.Sprintf("databricks: operation status error: %s\n%v", e.Msg, e.Err)
+func (e *DatabricksError) Unwrap() error {
+	return e.err
 }
 
-// RequestError is an error with the client's request
-type RequestError struct {
-	Msg string
-	Err error
+func (e *DatabricksError) Message() string {
+	return e.msg
 }
 
-func (e *RequestError) Error() string {
-	return fmt.Sprintf("databricks: request error: %s\n%v", e.Msg, e.Err)
+func (e *DatabricksError) CorrelationId() string {
+	return e.corrId
+}
+
+func (e *DatabricksError) ConnectionId() string {
+	return e.connId
+}
+
+func (e *DatabricksError) QueryId() string {
+	return e.queryId
+}
+
+func (e *DatabricksError) ErrorCondition() string {
+	return e.errCondition
+}
+
+func (e *DatabricksError) ErrorType() string {
+	return e.errType.String()
 }

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -16,16 +16,30 @@ import (
 )
 
 func main() {
-	// Setup
 	if err := godotenv.Load(); err != nil {
 		log.Fatal(err)
 	}
-	accessTokenInvalid()
+	//accessTokenInvalid()
+	//accessTokenMissing()
+	//serverHostnameInvalid()
+	//httpPathInvalid()
+	//portInvalid()
 	//userDoesNotHavePermission()
+	//tableIdentifierIsInvalid()
+	//tableNotFound()
+	//invalidSqlCommand()
+	//connectorMissingServerHostname()
+	//connectorMissingAccessToken()
+	//invalidDsnFormat()
+	//dsnTokenEmpty()
+	//dsnTokenMaxRowsInvalid()
+	//dsnTokenTimeoutInvalid()
+	//dsnTokenInvalidNoSuchHost()
 }
 
 // Returns:
-// databricks: driver error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: HTTP Response code: 403
+// databricks: connection error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: HTTP Response code: 403
+// TODO: error should describe invalid access token
 func accessTokenInvalid() {
 	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
 	if err != nil {
@@ -55,6 +69,135 @@ func accessTokenInvalid() {
 	}
 }
 
+// Returns:
+// databricks: connection error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: HTTP Response code: 401
+// TODO: error should describe missing access token
+func accessTokenMissing() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// ERR request failed (x5)
+// databricks: connection error: error connecting: host=e2-dogfood-invalid.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: Post "https://e2-dogfood-invalid.staging.cloud.databricks.com:443/sql/1.0/warehouses/e5edb16633f87f9b": dial tcp: lookup e2-dogfood-invalid.staging.cloud.databricks.com: no such host
+// TODO: what is dial tcp?
+func serverHostnameInvalid() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname("e2-dogfood-invalid.staging.cloud.databricks.com"),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: connection error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9binvalid: open session request error: HTTP Response code: 400
+func httpPathInvalid() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")+"invalid"),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// ERR request failed (x3)
+// databricks: connection error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=444, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: Post "https://e2-dogfood.staging.cloud.databricks.com:444/sql/1.0/warehouses/e5edb16633f87f9b": dial tcp 54.190.87.151:444: connect: operation timed out
+func portInvalid() {
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(444),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 60*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// ERR databricks: query state: ERROR_STATE connId=01eda22c-66d0-1a15-82cd-51463801f244 corrId=workflow-example queryId=01eda22c-6709-1b6d-af1c-af9993103703
+// ERR org.apache.hive.service.cli.HiveSQLException: Error running query: java.lang.SecurityException: User does not have permission SELECT on any file.
+// < spark stack trace >
+// ERR databricks: failed to execute query: query CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true) error="User does not have permission SELECT on any file." connId=01eda22c-66d0-1a15-82cd-51463801f244 corrId=workflow-example queryId=01eda22c-6709-1b6d-af1c-af9993103703
+// QueryFailureError for query 01eda22c-6709-1b6d-af1c-af9993103703 . databricks: query failure error: failed to execute query: User does not have permission SELECT on any file.
 func userDoesNotHavePermission() {
 	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
 	if err != nil {
@@ -89,5 +232,283 @@ func userDoesNotHavePermission() {
 		if errors.As(err, &queryFailureError) {
 			fmt.Println("QueryFailureError for query", queryFailureError.QueryId(), ".", queryFailureError)
 		}
+	}
+}
+
+// Returns:
+// ERR databricks: query state: ERROR_STATE connId=01eda22e-e9dc-1d8f-8160-de421eaf201e corrId=workflow-example queryId=01eda22e-ea07-15bb-9920-2ed8e2e8cf1e
+// ERR org.apache.hive.service.cli.HiveSQLException: Error running query: [INVALID_IDENTIFIER] org.apache.spark.sql.catalyst.parser.ParseException:
+// [INVALID_IDENTIFIER] The identifier diamonds-invalid is invalid. Please, consider quoting it with back-quotes as `diamonds-invalid`.(line 1, pos 31)
+//
+// == SQL ==
+// select max(carat) from diamonds-invalid
+// -------------------------------^^^
+// < spark stack trace >
+// ERR databricks: failed to run query error="\n[INVALID_IDENTIFIER] The identifier diamonds-invalid is invalid. Please, consider quoting it with back-quotes as `diamonds-invalid`.(line 1, pos 31)\n\n== SQL ==\nselect max(carat) from diamonds-invalid\n-------------------------------^^^\n" connId=01eda22e-e9dc-1d8f-8160-de421eaf201e corrId=workflow-example queryId=01eda22e-ea07-15bb-9920-2ed8e2e8cf1e
+// databricks: query failure error: failed to execute query:
+// [INVALID_IDENTIFIER] The identifier diamonds-invalid is invalid. Please, consider quoting it with back-quotes as `diamonds-invalid`.(line 1, pos 31)
+//
+// == SQL ==
+// select max(carat) from diamonds-invalid
+// -------------------------------^^^
+func tableIdentifierIsInvalid() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+
+	// Query row
+	var max float64
+	if err := db.QueryRowContext(ogCtx, "select max(carat) from diamonds-invalid").Scan(&max); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Printf("max carat in dataset is: %f\n", max)
+	}
+}
+
+// Returns:
+// ERR databricks: query state: ERROR_STATE connId=01eda22f-fde5-1b4c-904f-1f763f17f056 corrId=workflow-example queryId=01eda22f-fe0e-196c-a431-52e3d4f33fc4
+// ERR org.apache.hive.service.cli.HiveSQLException: Error running query: [TABLE_OR_VIEW_NOT_FOUND] org.apache.spark.sql.AnalysisException: [TABLE_OR_VIEW_NOT_FOUND] The table or view `diamonds-invalid` cannot be found. Verify the spelling and correctness of the schema and catalog.
+// If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
+// To tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.; line 1 pos 23
+// < spark stack trace >
+// < spark stack trace again >
+// ERR databricks: failed to run query error="[TABLE_OR_VIEW_NOT_FOUND] The table or view `diamonds-invalid` cannot be found. Verify the spelling and correctness of the schema and catalog.\nIf you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.\nTo tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.; line 1 pos 23" connId=01eda22f-fde5-1b4c-904f-1f763f17f056 corrId=workflow-example queryId=01eda22f-fe0e-196c-a431-52e3d4f33fc4
+// query failure error: failed to execute query: [TABLE_OR_VIEW_NOT_FOUND] The table or view `diamonds-invalid` cannot be found. Verify the spelling and correctness of the schema and catalog.
+// If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
+// To tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.; line 1 pos 23
+func tableNotFound() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+
+	// Query row
+	var max float64
+	if err := db.QueryRowContext(ogCtx, "select max(carat) from `diamonds-invalid`").Scan(&max); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Printf("max carat in dataset is: %f\n", max)
+	}
+}
+
+// Returns:
+// ERR databricks: query state: ERROR_STATE connId=01eda22f-fde5-1b4c-904f-1f763f17f056 corrId=workflow-example queryId=01eda22f-fe0e-196c-a431-52e3d4f33fc4
+// ERR org.apache.hive.service.cli.HiveSQLException: Error running query: [PARSE_SYNTAX_ERROR] org.apache.spark.sql.catalyst.parser.ParseException:
+// [PARSE_SYNTAX_ERROR] Syntax error at or near 'Selec'(line 1, pos 0)
+//
+// == SQL ==
+// Selec id from range(100)
+// ^^^
+// < spark stack trace > (x2)
+// ERR databricks: failed to execute query: query Selec id from range(100) error="\n[PARSE_SYNTAX_ERROR] Syntax error at or near 'Selec'(line 1, pos 0)\n\n== SQL ==\nSelec id from range(100)\n^^^\n" connId=01eda243-917b-1806-b517-4067df2495f4 corrId=workflow-example queryId=01eda243-91cd-1929-9ae7-d6382952c217
+// databricks: query failure error: failed to execute query:
+// [PARSE_SYNTAX_ERROR] Syntax error at or near 'Selec'(line 1, pos 0)
+//
+// == SQL ==
+// Selec id from range(100)
+// ^^^
+func invalidSqlCommand() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+
+	// Exec
+	if _, err := db.ExecContext(ogCtx, `Selec id from range(100)`); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// ERR request failed (x5)
+//
+//	databricks: connection error: error connecting: host= port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: Post "https://:443/sql/1.0/warehouses/e5edb16633f87f9b": dial tcp :443: connect: connection refused
+func connectorMissingServerHostname() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: connection error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: HTTP Response code: 401
+func connectorMissingAccessToken() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: authentication error: invalid DSN: invalid DSN port: strconv.Atoi: parsing "": invalid syntax
+func invalidDsnFormat() {
+	dsn := fmt.Sprintf("token%s%s%s%s", os.Getenv("DATABRICKS_ACCESSTOKEN"), os.Getenv("DATABRICKS_HOST"), os.Getenv("DATABRICKS_PORT"), os.Getenv("DATABRICKS_HTTPPATH"))
+	_, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: authentication error: invalid DSN: empty token: <nil>
+func dsnTokenEmpty() {
+	dsn := fmt.Sprintf("token:@%s:%s%s", os.Getenv("DATABRICKS_HOST"), os.Getenv("DATABRICKS_PORT"), os.Getenv("DATABRICKS_HTTPPATH"))
+	_, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: authentication error: invalid DSN: maxRows param is not an integer: strconv.Atoi: parsing "abc": invalid syntax
+func dsnTokenMaxRowsInvalid() {
+	dsn := fmt.Sprintf("token:%s@%s:%s%s?maxRows=abc", os.Getenv("DATABRICKS_ACCESSTOKEN"), os.Getenv("DATABRICKS_HOST"), os.Getenv("DATABRICKS_PORT"), os.Getenv("DATABRICKS_HTTPPATH"))
+	_, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: authentication error: invalid DSN: timeout param is not an integer: strconv.Atoi: parsing "abc": invalid syntax
+func dsnTokenTimeoutInvalid() {
+	dsn := fmt.Sprintf("token:%s@%s:%s%s?timeout=abc", os.Getenv("DATABRICKS_ACCESSTOKEN"), os.Getenv("DATABRICKS_HOST"), os.Getenv("DATABRICKS_PORT"), os.Getenv("DATABRICKS_HTTPPATH"))
+	_, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Returns:
+// databricks: connection error: error connecting: host=abc port=123, httpPath=: open session request error: Post "https://abc:123": dial tcp: lookup abc: no such host
+func dsnTokenInvalidNoSuchHost() {
+	dsn := fmt.Sprintf("abc:123")
+	_, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := sql.Open("databricks", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	dbsql "github.com/databricks/databricks-sql-go"
+	dbsqlctx "github.com/databricks/databricks-sql-go/driverctx"
+	dbsqlerror "github.com/databricks/databricks-sql-go/error"
+	"github.com/joho/godotenv"
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	// Setup
+	if err := godotenv.Load(); err != nil {
+		log.Fatal(err)
+	}
+	accessTokenInvalid()
+	//userDoesNotHavePermission()
+}
+
+// Returns:
+// databricks: driver error: error connecting: host=e2-dogfood.staging.cloud.databricks.com port=443, httpPath=/sql/1.0/warehouses/e5edb16633f87f9b: open session request error: HTTP Response code: 403
+func accessTokenInvalid() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")+"invalid"),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func userDoesNotHavePermission() {
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithUserAgentEntry("workflow-example"),
+		dbsql.WithInitialNamespace("hive_metastore", "default"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ogCtx := dbsqlctx.NewContextWithCorrelationId(context.Background(), "workflow-example")
+
+	// Ping
+	ctx1, cancel := context.WithTimeout(ogCtx, 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx1); err != nil {
+		log.Fatal(err)
+	}
+
+	// Exec
+	if _, err := db.ExecContext(ogCtx, `CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true)`); err != nil {
+		var queryFailureError *dbsqlerror.QueryFailureError
+		if errors.As(err, &queryFailureError) {
+			fmt.Println("QueryFailureError for query", queryFailureError.QueryId(), ".", queryFailureError)
+		}
+	}
+}

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -27,7 +27,7 @@ func main() {
 	//userDoesNotHavePermission()
 	//tableIdentifierIsInvalid()
 	//tableNotFound()
-	//invalidSqlCommand()
+	invalidSqlCommand()
 	//connectorMissingServerHostname()
 	//connectorMissingAccessToken()
 	//invalidDsnFormat()
@@ -197,7 +197,7 @@ func portInvalid() {
 // ERR org.apache.hive.service.cli.HiveSQLException: Error running query: java.lang.SecurityException: User does not have permission SELECT on any file.
 // < spark stack trace >
 // ERR databricks: failed to execute query: query CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true) error="User does not have permission SELECT on any file." connId=01eda22c-66d0-1a15-82cd-51463801f244 corrId=workflow-example queryId=01eda22c-6709-1b6d-af1c-af9993103703
-// QueryFailureError for query 01eda22c-6709-1b6d-af1c-af9993103703 . databricks: query failure error: failed to execute query: User does not have permission SELECT on any file.
+// ExecutionError for query 01eda22c-6709-1b6d-af1c-af9993103703 . databricks: query failure error: failed to execute query: User does not have permission SELECT on any file.
 func userDoesNotHavePermission() {
 	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
 	if err != nil {
@@ -228,9 +228,9 @@ func userDoesNotHavePermission() {
 
 	// Exec
 	if _, err := db.ExecContext(ogCtx, `CREATE TABLE IF NOT EXISTS diamonds USING CSV LOCATION '/databricks-datasets/Rdatasets/data-001/csv/ggplot2/diamonds.csv' options (header = true, inferSchema = true)`); err != nil {
-		var queryFailureError *dbsqlerror.QueryFailureError
+		var queryFailureError *dbsqlerror.ExecutionError
 		if errors.As(err, &queryFailureError) {
-			fmt.Println("QueryFailureError for query", queryFailureError.QueryId(), ".", queryFailureError)
+			fmt.Println("ExecutionError for query", queryFailureError.QueryId(), ".", queryFailureError)
 		}
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -194,7 +194,7 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 	case "header":
 		protocolFactory = thrift.NewTHeaderProtocolFactoryConf(tcfg)
 	default:
-		return nil, dbsqlerror.NewConnectionError(nil, fmt.Sprintf("invalid protocol specified %s", cfg.ThriftProtocol), nil)
+		return nil, dbsqlerror.NewConnectionError(context.TODO(), fmt.Sprintf("invalid protocol specified %s", cfg.ThriftProtocol), nil)
 	}
 	if cfg.ThriftDebugClientProtocol {
 		protocolFactory = thrift.NewTDebugProtocolFactoryWithLogger(protocolFactory, "client:", thrift.StdLogger(nil))
@@ -207,7 +207,7 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 	case "http":
 		if httpclient == nil {
 			if cfg.Authenticator == nil {
-				return nil, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrNoAuthenticationMethod, nil)
+				return nil, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrNoAuthenticationMethod, nil)
 			}
 			httpclient = RetryableClient(cfg)
 		}
@@ -222,13 +222,13 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 		thriftHttpClient.SetHeader("User-Agent", userAgent)
 
 	default:
-		return nil, dbsqlerror.NewDriverError(nil, fmt.Sprintf("unsupported transport `%s`", cfg.ThriftTransport), nil)
+		return nil, dbsqlerror.NewDriverError(context.TODO(), fmt.Sprintf("unsupported transport `%s`", cfg.ThriftTransport), nil)
 	}
 	if err != nil {
-		return nil, dbsqlerror.NewConnectionError(nil, dbsqlerror.ErrInvalidURL, err)
+		return nil, dbsqlerror.NewConnectionError(context.TODO(), dbsqlerror.ErrInvalidURL, err)
 	}
 	if err = tTrans.Open(); err != nil {
-		return nil, dbsqlerror.NewConnectionError(nil, fmt.Sprintf("failed to open http transport for endpoint %s", endpoint), err)
+		return nil, dbsqlerror.NewConnectionError(context.TODO(), fmt.Sprintf("failed to open http transport for endpoint %s", endpoint), err)
 	}
 	iprot := protocolFactory.GetProtocol(tTrans)
 	oprot := protocolFactory.GetProtocol(tTrans)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -249,16 +249,15 @@ func CheckStatus(resp interface{}) error {
 	if ok {
 		status := rpcresp.GetStatus()
 		if status.StatusCode == cli_service.TStatusCode_ERROR_STATUS {
-			return errors.New(status.GetErrorMessage())
+			return &dbsqlerror.OperationStatusError{Msg: status.GetErrorMessage()}
 		}
 		if status.StatusCode == cli_service.TStatusCode_INVALID_HANDLE_STATUS {
-			return errors.New("thrift: invalid handle")
+			return &dbsqlerror.OperationStatusError{Msg: "thrift: invalid handle"}
 		}
 
 		// SUCCESS, SUCCESS_WITH_INFO, STILL_EXECUTING are ok
 		return nil
 	}
-
 	return &dbsqlerror.OperationStatusError{Msg: "thrift: invalid response"}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -194,7 +194,7 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 	case "header":
 		protocolFactory = thrift.NewTHeaderProtocolFactoryConf(tcfg)
 	default:
-		return nil, dbsqlerror.NewConnectionError(context.TODO(), fmt.Sprintf("invalid protocol specified %s", cfg.ThriftProtocol), nil)
+		return nil, dbsqlerror.NewRequestError(context.TODO(), fmt.Sprintf("invalid protocol specified %s", cfg.ThriftProtocol), nil)
 	}
 	if cfg.ThriftDebugClientProtocol {
 		protocolFactory = thrift.NewTDebugProtocolFactoryWithLogger(protocolFactory, "client:", thrift.StdLogger(nil))
@@ -207,7 +207,7 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 	case "http":
 		if httpclient == nil {
 			if cfg.Authenticator == nil {
-				return nil, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrNoAuthenticationMethod, nil)
+				return nil, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrNoAuthenticationMethod, nil)
 			}
 			httpclient = RetryableClient(cfg)
 		}
@@ -222,13 +222,13 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 		thriftHttpClient.SetHeader("User-Agent", userAgent)
 
 	default:
-		return nil, dbsqlerror.NewDriverError(context.TODO(), fmt.Sprintf("unsupported transport `%s`", cfg.ThriftTransport), nil)
+		return nil, dbsqlerror.NewSystemFault(context.TODO(), fmt.Sprintf("unsupported transport `%s`", cfg.ThriftTransport), nil)
 	}
 	if err != nil {
-		return nil, dbsqlerror.NewConnectionError(context.TODO(), dbsqlerror.ErrInvalidURL, err)
+		return nil, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidURL, err)
 	}
 	if err = tTrans.Open(); err != nil {
-		return nil, dbsqlerror.NewConnectionError(context.TODO(), fmt.Sprintf("failed to open http transport for endpoint %s", endpoint), err)
+		return nil, dbsqlerror.NewRequestError(context.TODO(), fmt.Sprintf("failed to open http transport for endpoint %s", endpoint), err)
 	}
 	iprot := protocolFactory.GetProtocol(tTrans)
 	oprot := protocolFactory.GetProtocol(tTrans)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/url"
@@ -183,21 +184,21 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	}
 	parsedURL, err := url.Parse(fullDSN)
 	if err != nil {
-		return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNFormat, err)
+		return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNFormat, err)
 	}
 	ucfg := UserConfig{}.WithDefaults()
 	ucfg.Protocol = parsedURL.Scheme
 	ucfg.Host = parsedURL.Hostname()
 	port, err := strconv.Atoi(parsedURL.Port())
 	if err != nil {
-		return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNPort, err)
+		return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNPort, err)
 	}
 	ucfg.Port = port
 	name := parsedURL.User.Username()
 	if name == "token" {
 		pass, ok := parsedURL.User.Password()
 		if pass == "" {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
 		}
 		if ok {
 			ucfg.AccessToken = pass
@@ -208,7 +209,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 		}
 	} else {
 		if name != "" {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrBasicAuthNotSupported, err)
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrBasicAuthNotSupported, err)
 		}
 	}
 	ucfg.HTTPPath = parsedURL.Path
@@ -217,7 +218,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if maxRowsStr != "" {
 		maxRows, err := strconv.Atoi(maxRowsStr)
 		if err != nil {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNMaxRows, err)
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNMaxRows, err)
 		}
 		// we should always have at least some page size
 		if maxRows != 0 {
@@ -230,7 +231,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if timeoutStr != "" {
 		timeoutSeconds, err := strconv.Atoi(timeoutStr)
 		if err != nil {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNTimeout, err)
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNTimeout, err)
 		}
 		ucfg.QueryTimeout = time.Duration(timeoutSeconds) * time.Second
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,7 +198,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if name == "token" {
 		pass, ok := parsedURL.User.Password()
 		if pass == "" {
-			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
+			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNPATIsEmpty, err)
 		}
 		if ok {
 			ucfg.AccessToken = pass

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if name == "token" {
 		pass, ok := parsedURL.User.Password()
 		if pass == "" {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNEmptyToken, err)
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
 		}
 		if ok {
 			ucfg.AccessToken = pass

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,21 +183,21 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	}
 	parsedURL, err := url.Parse(fullDSN)
 	if err != nil {
-		return UserConfig{}, &dbsqlerror.ConnectionError{Msg: "invalid DSN: invalid format", Err: err}
+		return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNFormat, err)
 	}
 	ucfg := UserConfig{}.WithDefaults()
 	ucfg.Protocol = parsedURL.Scheme
 	ucfg.Host = parsedURL.Hostname()
 	port, err := strconv.Atoi(parsedURL.Port())
 	if err != nil {
-		return UserConfig{}, &dbsqlerror.ConnectionError{Msg: "invalid DSN: invalid DSN port", Err: err}
+		return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNPort, err)
 	}
 	ucfg.Port = port
 	name := parsedURL.User.Username()
 	if name == "token" {
 		pass, ok := parsedURL.User.Password()
 		if pass == "" {
-			return UserConfig{},  &dbsqlerror.ConnectionError{Msg: "invalid DSN: empty token", Err: err}
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNEmptyToken, err)
 		}
 		if ok {
 			ucfg.AccessToken = pass
@@ -208,7 +208,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 		}
 	} else {
 		if name != "" {
-			return UserConfig{}, &dbsqlerror.ConnectionError{Msg: "invalid DSN: basic auth not enabled", Err: err}
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrBasicAuthNotSupported, err)
 		}
 	}
 	ucfg.HTTPPath = parsedURL.Path
@@ -217,7 +217,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if maxRowsStr != "" {
 		maxRows, err := strconv.Atoi(maxRowsStr)
 		if err != nil {
-			return UserConfig{}, &dbsqlerror.ConnectionError{Msg: "invalid DSN: maxRows param is not an integer", Err: err}
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNMaxRows, err)
 		}
 		// we should always have at least some page size
 		if maxRows != 0 {
@@ -230,7 +230,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if timeoutStr != "" {
 		timeoutSeconds, err := strconv.Atoi(timeoutStr)
 		if err != nil {
-			return UserConfig{}, &dbsqlerror.ConnectionError{Msg: "invalid DSN: timeout param is not an integer", Err: err}
+			return UserConfig{}, dbsqlerror.NewAuthenticationError(nil, dbsqlerror.ErrInvalidDSNTimeout, err)
 		}
 		ucfg.QueryTimeout = time.Duration(timeoutSeconds) * time.Second
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,21 +184,21 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	}
 	parsedURL, err := url.Parse(fullDSN)
 	if err != nil {
-		return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNFormat, err)
+		return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNFormat, err)
 	}
 	ucfg := UserConfig{}.WithDefaults()
 	ucfg.Protocol = parsedURL.Scheme
 	ucfg.Host = parsedURL.Hostname()
 	port, err := strconv.Atoi(parsedURL.Port())
 	if err != nil {
-		return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNPort, err)
+		return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNPort, err)
 	}
 	ucfg.Port = port
 	name := parsedURL.User.Username()
 	if name == "token" {
 		pass, ok := parsedURL.User.Password()
 		if pass == "" {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
+			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNTokenIsEmpty, err)
 		}
 		if ok {
 			ucfg.AccessToken = pass
@@ -209,7 +209,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 		}
 	} else {
 		if name != "" {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrBasicAuthNotSupported, err)
+			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrBasicAuthNotSupported, err)
 		}
 	}
 	ucfg.HTTPPath = parsedURL.Path
@@ -218,7 +218,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if maxRowsStr != "" {
 		maxRows, err := strconv.Atoi(maxRowsStr)
 		if err != nil {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNMaxRows, err)
+			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNMaxRows, err)
 		}
 		// we should always have at least some page size
 		if maxRows != 0 {
@@ -231,7 +231,7 @@ func ParseDSN(dsn string) (UserConfig, error) {
 	if timeoutStr != "" {
 		timeoutSeconds, err := strconv.Atoi(timeoutStr)
 		if err != nil {
-			return UserConfig{}, dbsqlerror.NewAuthenticationError(context.TODO(), dbsqlerror.ErrInvalidDSNTimeout, err)
+			return UserConfig{}, dbsqlerror.NewRequestError(context.TODO(), dbsqlerror.ErrInvalidDSNTimeout, err)
 		}
 		ucfg.QueryTimeout = time.Duration(timeoutSeconds) * time.Second
 	}

--- a/statement.go
+++ b/statement.go
@@ -26,14 +26,14 @@ func (s *stmt) NumInput() int {
 //
 // Deprecated: Use StmtExecContext instead.
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return nil, &dbsqlerror.RequestError{Msg: ErrNotImplemented}
+	return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrNotImplemented, nil)
 }
 
 // Query is not implemented.
 //
 // Deprecated: Use StmtQueryContext instead.
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	return nil, &dbsqlerror.RequestError{Msg: ErrNotImplemented}
+	return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrNotImplemented, nil)
 }
 
 // ExecContext executes a query that doesn't return rows, such

--- a/statement.go
+++ b/statement.go
@@ -26,14 +26,14 @@ func (s *stmt) NumInput() int {
 //
 // Deprecated: Use StmtExecContext instead.
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrNotImplemented, nil)
+	return nil, dbsqlerror.NewDriverError(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
 }
 
 // Query is not implemented.
 //
 // Deprecated: Use StmtQueryContext instead.
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	return nil, dbsqlerror.NewDriverError(nil, dbsqlerror.ErrNotImplemented, nil)
+	return nil, dbsqlerror.NewDriverError(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
 }
 
 // ExecContext executes a query that doesn't return rows, such

--- a/statement.go
+++ b/statement.go
@@ -3,7 +3,7 @@ package dbsql
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
+	dbsqlerror "github.com/databricks/databricks-sql-go/error"
 )
 
 type stmt struct {
@@ -26,14 +26,14 @@ func (s *stmt) NumInput() int {
 //
 // Deprecated: Use StmtExecContext instead.
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return nil, errors.New(ErrNotImplemented)
+	return nil, &dbsqlerror.RequestError{Msg: ErrNotImplemented}
 }
 
 // Query is not implemented.
 //
 // Deprecated: Use StmtQueryContext instead.
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	return nil, errors.New(ErrNotImplemented)
+	return nil, &dbsqlerror.RequestError{Msg: ErrNotImplemented}
 }
 
 // ExecContext executes a query that doesn't return rows, such

--- a/statement.go
+++ b/statement.go
@@ -26,14 +26,14 @@ func (s *stmt) NumInput() int {
 //
 // Deprecated: Use StmtExecContext instead.
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return nil, dbsqlerror.NewDriverError(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
+	return nil, dbsqlerror.NewSystemFault(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
 }
 
 // Query is not implemented.
 //
 // Deprecated: Use StmtQueryContext instead.
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	return nil, dbsqlerror.NewDriverError(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
+	return nil, dbsqlerror.NewSystemFault(context.TODO(), dbsqlerror.ErrNotImplemented, nil)
 }
 
 // ExecContext executes a query that doesn't return rows, such


### PR DESCRIPTION
### Issue
https://github.com/databricks/databricks-sql-go/issues/68

### Plan
The following DBSQL error categories will be exposed to clients:
**RequestError**
**ExecutionError**
**SystemFault**

The standard Databricks error expose fields `err`, `corrId`, `connId`. ExecutionError will also expose `sqlState`, `queryId`, and `errClass`. SystemFault will also expose `isRetryable`. 

### Remaining work
* compare errors with JDBC/ODBC
* investigate returned headers to provide granularity around errors (particularly SystemFault)
* warehouses vs clusters have slightly different errors