### PR TITLE
Update DriverVersion in Config to 1.0.1

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -86,6 +86,7 @@ type connOption func(*config.Config)
 func NewConnector(options ...connOption) (driver.Connector, error) {
 	// config with default options
 	cfg := config.WithDefaults()
+	cfg.DriverVersion = DriverVersion
 
 	for _, opt := range options {
 		opt(cfg)

--- a/connector_test.go
+++ b/connector_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var ExpectedDriverVersion = "1.0.1"
+
 func TestNewConnector(t *testing.T) {
 	t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {
 		host := "databricks-host"
@@ -52,6 +54,7 @@ func TestNewConnector(t *testing.T) {
 			RetryWaitMax:   60 * time.Second,
 		}
 		expectedCfg := config.WithDefaults()
+		expectedCfg.DriverVersion = ExpectedDriverVersion
 		expectedCfg.UserConfig = expectedUserConfig
 		coni, ok := con.(*connector)
 		require.True(t, ok)
@@ -117,6 +120,7 @@ func TestNewConnector(t *testing.T) {
 			RetryWaitMax:  0,
 		}
 		expectedCfg := config.WithDefaults()
+		expectedCfg.DriverVersion = ExpectedDriverVersion
 		expectedCfg.UserConfig = expectedUserConfig
 		coni, ok := con.(*connector)
 		require.True(t, ok)

--- a/connector_test.go
+++ b/connector_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ExpectedDriverVersion = "1.0.1"
-
 func TestNewConnector(t *testing.T) {
 	t.Run("Connector initialized with functional options should have all options set", func(t *testing.T) {
 		host := "databricks-host"
@@ -54,7 +52,7 @@ func TestNewConnector(t *testing.T) {
 			RetryWaitMax:   60 * time.Second,
 		}
 		expectedCfg := config.WithDefaults()
-		expectedCfg.DriverVersion = ExpectedDriverVersion
+		expectedCfg.DriverVersion = DriverVersion
 		expectedCfg.UserConfig = expectedUserConfig
 		coni, ok := con.(*connector)
 		require.True(t, ok)
@@ -88,6 +86,7 @@ func TestNewConnector(t *testing.T) {
 		}
 		expectedCfg := config.WithDefaults()
 		expectedCfg.UserConfig = expectedUserConfig
+		expectedCfg.DriverVersion = DriverVersion
 		coni, ok := con.(*connector)
 		require.True(t, ok)
 		assert.Nil(t, err)
@@ -120,7 +119,7 @@ func TestNewConnector(t *testing.T) {
 			RetryWaitMax:  0,
 		}
 		expectedCfg := config.WithDefaults()
-		expectedCfg.DriverVersion = ExpectedDriverVersion
+		expectedCfg.DriverVersion = DriverVersion
 		expectedCfg.UserConfig = expectedUserConfig
 		coni, ok := con.(*connector)
 		require.True(t, ok)

--- a/driver.go
+++ b/driver.go
@@ -13,6 +13,8 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
+var DriverVersion = "1.0.1" // update version before each release
+
 type databricksDriver struct{}
 
 // Open returns a new connection to Databricks database with a DSN string.

--- a/driver_test.go
+++ b/driver_test.go
@@ -26,6 +26,7 @@ func TestOOpenConnector(t *testing.T) {
 		}
 		expectedCfg := config.WithDefaults()
 		expectedCfg.UserConfig = expectedUserConfig.WithDefaults()
+		expectedCfg.DriverVersion = DriverVersion
 		d := &databricksDriver{}
 		c, err := d.OpenConnector(fmt.Sprintf("token:%s@%s:%d/%s", accessToken, host, port, httpPath))
 		require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,7 +167,7 @@ func WithDefaults() *Config {
 		PingTimeout:               60 * time.Second,
 		CanUseMultipleCatalogs:    true,
 		DriverName:                "godatabrickssqlconnector", // important. Do not change
-		DriverVersion:             "0.9.0",
+		DriverVersion:             "1.0.1",
 		ThriftProtocol:            "binary",
 		ThriftTransport:           "http",
 		ThriftProtocolVersion:     cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,7 +167,6 @@ func WithDefaults() *Config {
 		PingTimeout:               60 * time.Second,
 		CanUseMultipleCatalogs:    true,
 		DriverName:                "godatabrickssqlconnector", // important. Do not change
-		DriverVersion:             "1.0.1",
 		ThriftProtocol:            "binary",
 		ThriftTransport:           "http",
 		ThriftProtocolVersion:     cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6,


### PR DESCRIPTION
## Description
In this PR, we update the driver version to 1.0.1 to reflect the latest cut. We also move the DriverVersion to a more visible const in `driver.go`. 

(Already merged) Most of the code in `driver.go:Open` is the same as `driver.go:OpenConnector` so these are merged.