### PR TITLE
use ClientProtocolI64

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -36,10 +36,10 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, wrapErr(err, "error initializing thrift client")
 	}
-
+	protocolVersion := int64(c.cfg.ThriftProtocolVersion)
 	session, err := tclient.OpenSession(ctx, &cli_service.TOpenSessionReq{
-		ClientProtocol: c.cfg.ThriftProtocolVersion,
-		Configuration:  make(map[string]string),
+		ClientProtocolI64: &protocolVersion,
+		Configuration:     make(map[string]string),
 		InitialNamespace: &cli_service.TNamespace{
 			CatalogName: catalogName,
 			SchemaName:  schemaName,

--- a/testdata/OpenSessionSuccess.json
+++ b/testdata/OpenSessionSuccess.json
@@ -2,7 +2,7 @@
  "status": {
   "statusCode": "SUCCESS_STATUS"
  },
- "serverProtocolVersion": "SPARK_CLI_SERVICE_PROTOCOL_V2",
+ "serverProtocolVersion": "SPARK_CLI_SERVICE_PROTOCOL_V6",
  "sessionHandle": {
   "sessionId": {
    "guid": "Ae1mneMGHoSo6JW/won/xg==",


### PR DESCRIPTION
Our thrift server does not actually honour ClientProtocol. We have to use ClientProtocolI64.

Signed-off-by: Andre Furlan <andre.furlan@databricks.com>