### PR TITLE
Do not override global logger time format

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -45,11 +45,6 @@ func init() {
 	// for tty terminal enable pretty logs
 	if isatty.IsTerminal(os.Stdout.Fd()) && runtime.GOOS != "windows" {
 		Logger = &DBSQLLogger{Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr})}
-	} else {
-		// UNIX Time is faster and smaller than most timestamps
-		// If you set zerolog.TimeFieldFormat to an empty string,
-		// logs will write with UNIX time.
-		zerolog.TimeFieldFormat = ""
 	}
 	// by default only log warns or above
 	loglvl := zerolog.WarnLevel


### PR DESCRIPTION
The zerolog timestamp format is global and used by all loggers by default. Mutating this from within a library can introduce unexpected behavioral changes to consuming applications.