### PR TITLE
Improve error message and retry behaviour

### DIFF
--- a/driver_e2e_test.go
+++ b/driver_e2e_test.go
@@ -266,7 +266,7 @@ func TestContextTimeoutExample(t *testing.T) {
 
 	defer ts.Close()
 
-	db, err := sql.Open("databricks", ts.URL)
+	db, err := sql.Open("databricks", ts.URL+"/path")
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -363,7 +363,7 @@ func TestRetries(t *testing.T) {
 
 		connector, err := NewConnector(
 			WithServerHostname("localhost"),
-			WithHTTPPath("/500-5-retries"),
+			WithHTTPPath("/503-5-retries"),
 			WithPort(port),
 			WithRetries(2, 10*time.Millisecond, 1*time.Second),
 		)
@@ -397,7 +397,7 @@ func TestRetries(t *testing.T) {
 
 		connector, err := NewConnector(
 			WithServerHostname("localhost"),
-			WithHTTPPath("/500-5-retries"),
+			WithHTTPPath("/429-2-retries"),
 			WithPort(port),
 			WithRetries(-1, 0, 0),
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,10 +36,19 @@ type Config struct {
 }
 
 // ToEndpointURL generates the endpoint URL from Config that a Thrift client will connect to
-func (c *Config) ToEndpointURL() string {
+func (c *Config) ToEndpointURL() (string, error) {
 	var userInfo string
 	endpointUrl := fmt.Sprintf("%s://%s%s:%d%s", c.Protocol, userInfo, c.Host, c.Port, c.HTTPPath)
-	return endpointUrl
+	if c.Host == "" {
+		return endpointUrl, errors.New("databricks: missing Hostname")
+	}
+	if c.Port == 0 {
+		return endpointUrl, errors.New("databricks: missing Port")
+	}
+	if c.HTTPPath == "" && c.Host != "localhost" {
+		return endpointUrl, errors.New("databricks: missing HTTP Path")
+	}
+	return endpointUrl, nil
 }
 
 // DeepCopy returns a true deep copy of Config

--- a/testserver.go
+++ b/testserver.go
@@ -12,7 +12,7 @@ type thriftHandler struct {
 	processor               thrift.TProcessor
 	inPfactory, outPfactory thrift.TProtocolFactory
 	count503_2_retries      int
-	count500_5_retries      int
+	count503_5_retries      int
 	count429_2_retries      int
 }
 
@@ -36,13 +36,13 @@ func (h *thriftHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			h.count429_2_retries = 0
 		}
-	case "/500-5-retries":
-		if h.count500_5_retries <= 5 {
-			w.WriteHeader(http.StatusInternalServerError)
-			h.count500_5_retries++
+	case "/503-5-retries":
+		if h.count503_5_retries <= 5 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			h.count503_5_retries++
 			return
 		} else {
-			h.count500_5_retries = 0
+			h.count503_5_retries = 0
 		}
 	}
 


### PR DESCRIPTION
Be more restrictive on retries: only retry on 429 and 503 StatusCodes or connection errors.

Return better error messages regarding retry reasons and invalid user input.
