### PR TITLE
Updated retry behaviour

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,15 @@
 package client
 
-import "testing"
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
 
 func TestSprintByteId(t *testing.T) {
 	type args struct {
@@ -34,4 +43,125 @@ func TestSprintByteId(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetryPolicy(t *testing.T) {
+
+	t.Run("test handling url error", func(t *testing.T) {
+		urlErr := &url.Error{Err: errors.New("EOF")}
+		resp := &http.Response{}
+
+		urlErr.Err = x509.UnknownAuthorityError{}
+		b, err := RetryPolicy(context.Background(), resp, urlErr)
+		require.False(t, b)
+		require.Equal(t, urlErr, err)
+
+		errMsgs := []string{"stopped after 12 redirects", "unsupported protocol scheme", "certificate is not trusted"}
+		for _, msg := range errMsgs {
+			urlErr.Err = errors.New(msg)
+			b, err := RetryPolicy(context.Background(), resp, urlErr)
+			require.False(t, b)
+			require.Equal(t, urlErr, err)
+		}
+
+		urlErr.Err = errors.New("other error")
+		b, err = RetryPolicy(context.Background(), resp, urlErr)
+		require.True(t, b)
+		require.Nil(t, err)
+
+		b, err = RetryPolicy(context.Background(), resp, errors.New("non-url error"))
+		require.True(t, b)
+		require.Nil(t, err)
+
+	})
+
+	t.Run("test handling status codes", func(t *testing.T) {
+		resp := &http.Response{}
+		// 429 nd 503 are always retryable
+		retryableCodes := []int{429, 503}
+		// maybe retryable codes: 0 and >= 500, but not 501
+		maybeRetryableCodes := []int{500, 502, 504, 505, 506, 507, 508, 511, 0, 777}
+
+		nonRetryableCodes := []int{200, 300, 400, 501}
+
+		idempotentOps := []clientMethod{closeSession, getResultSetMetadata, getOperationStatus, closeOperation, cancelOperation}
+		nonIdempotentOps := []clientMethod{openSession, fetchResults, executeStatement}
+
+		cancelled, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		for _, code := range retryableCodes {
+			for _, op := range idempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.True(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+
+			for _, op := range nonIdempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.True(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+		}
+
+		for _, code := range maybeRetryableCodes {
+			for _, op := range idempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.True(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+
+			for _, op := range nonIdempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.False(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+		}
+
+		for _, code := range nonRetryableCodes {
+			for _, op := range idempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.False(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+
+			for _, op := range nonIdempotentOps {
+				resp.StatusCode = code
+				ctx := context.WithValue(context.Background(), ClientMethod, op)
+				retry, _ := RetryPolicy(ctx, resp, nil)
+				require.False(t, retry)
+
+				// should always return false if the context is cancelled or timed out
+				retry, _ = RetryPolicy(cancelled, resp, nil)
+				require.False(t, retry)
+			}
+		}
+
+	})
+
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -84,8 +84,8 @@ func TestRetryPolicy(t *testing.T) {
 
 		nonRetryableCodes := []int{200, 300, 400, 501}
 
-		idempotentOps := []clientMethod{closeSession, getResultSetMetadata, getOperationStatus, closeOperation, cancelOperation}
-		nonIdempotentOps := []clientMethod{openSession, fetchResults, executeStatement}
+		idempotentOps := []clientMethod{closeSession, getResultSetMetadata, getOperationStatus, closeOperation, cancelOperation, fetchResults}
+		nonIdempotentOps := []clientMethod{openSession, executeStatement}
 
 		cancelled, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/testserver.go
+++ b/testserver.go
@@ -47,7 +47,7 @@ func (h *thriftHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/429-5-retries":
 		if h.count503_5_retries <= 5 {
 			w.Header().Set("Retry-After", "12")
-			w.WriteHeader(http.StatusServiceUnavailable)
+			w.WriteHeader(http.StatusTooManyRequests)
 			h.count503_5_retries++
 			return
 		} else {


### PR DESCRIPTION
- retry on 500 status codes if the server operation is idempotent
- retry on request errors except: too many redirects, invalid protocol scheme,  TLS cert verification failure
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>