### PR TITLE
Bug fix for null values in complex types

### DIFF
--- a/internal/rows/arrowbased/arrowRows.go
+++ b/internal/rows/arrowbased/arrowRows.go
@@ -701,6 +701,9 @@ func (vcm *arrowValueContainerMaker) makeColumnValueContainer(t arrow.DataType, 
 
 		return svc, nil
 
+	case *arrow.NullType:
+		return nullContainer, nil
+
 	default:
 		return nil, errors.Errorf(errArrowRowsUnhandledArrowType(t.String()))
 	}

--- a/internal/rows/arrowbased/testdata/nullsInComplexTypes.json
+++ b/internal/rows/arrowbased/testdata/nullsInComplexTypes.json
@@ -1,0 +1,106 @@
+{
+ "status": {
+  "statusCode": "SUCCESS_STATUS"
+ },
+ "operationHandle": {
+  "operationId": {
+   "guid": "Ae3/5kgLHHCdBXUYvmHrVA==",
+   "secret": "M41SnYJyRuuEgstBlGaDnQ=="
+  },
+  "operationType": "EXECUTE_STATEMENT",
+  "hasResultSet": true
+ },
+ "directResults": {
+  "operationStatus": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "operationState": "FINISHED_STATE",
+   "operationStarted": 1685560003513,
+   "operationCompleted": 1685560003570
+  },
+  "resultSetMetadata": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "schema": {
+    "columns": [
+     {
+      "columnName": "sample_map",
+      "typeDesc": {
+       "types": [
+        {
+         "primitiveEntry": {
+          "type": "MAP_TYPE"
+         }
+        }
+       ]
+      },
+      "position": 1,
+      "comment": ""
+     },
+     {
+      "columnName": "sample_struct",
+      "typeDesc": {
+       "types": [
+        {
+         "primitiveEntry": {
+          "type": "STRUCT_TYPE"
+         }
+        }
+       ]
+      },
+      "position": 2,
+      "comment": ""
+     },
+     {
+      "columnName": "sample_list",
+      "typeDesc": {
+       "types": [
+        {
+         "primitiveEntry": {
+          "type": "ARRAY_TYPE"
+         }
+        }
+       ]
+      },
+      "position": 3,
+      "comment": ""
+     }
+    ]
+   },
+   "resultFormat": "ARROW_BASED_SET",
+   "lz4Compressed": false,
+   "arrowSchema": "/////9gEAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAMAAADcAgAAGAEAAAQAAADW+///FAAAALwAAADwAAAAAAAADOwAAAACAAAAcAAAAAQAAAC0/P//CAAAAEQAAAA5AAAAeyJ0eXBlIjoiYXJyYXkiLCJlbGVtZW50VHlwZSI6InZvaWQiLCJjb250YWluc051bGwiOnRydWV9AAAAFwAAAFNwYXJrOkRhdGFUeXBlOkpzb25UeXBlABz9//8IAAAAFAAAAAsAAABBUlJBWTxWT0lEPgAWAAAAU3Bhcms6RGF0YVR5cGU6U3FsTmFtZQAAAQAAAAQAAADi/P//FAAAABQAAAAUAAAAAAABARAAAAAAAAAAAAAAAHT8//8HAAAAZWxlbWVudACE/P//CwAAAHNhbXBsZV9saXN0AOb8//8UAAAANAEAAJwBAAAAAAANmAEAAAIAAADQAAAABAAAAMT9//8IAAAApAAAAJgAAAB7InR5cGUiOiJzdHJ1Y3QiLCJmaWVsZHMiOlt7Im5hbWUiOiJGaWVsZDEiLCJ0eXBlIjoidm9pZCIsIm51bGxhYmxlIjp0cnVlLCJtZXRhZGF0YSI6e319LHsibmFtZSI6IkZpZWxkMiIsInR5cGUiOiJ2b2lkIiwibnVsbGFibGUiOnRydWUsIm1ldGFkYXRhIjp7fX1dfQAAAAAXAAAAU3Bhcms6RGF0YVR5cGU6SnNvblR5cGUAjP7//wgAAAAsAAAAIgAAAFNUUlVDVDxGaWVsZDE6IFZPSUQsIEZpZWxkMjogVk9JRD4AABYAAABTcGFyazpEYXRhVHlwZTpTcWxOYW1lAAACAAAAOAAAAAQAAABu/v//FAAAABQAAAAUAAAAAAABARAAAAAAAAAAAAAAAAD+//8GAAAARmllbGQyAACe/v//FAAAABQAAAAUAAAAAAABARAAAAAAAAAAAAAAADD+//8GAAAARmllbGQxAABA/v//DQAAAHNhbXBsZV9zdHJ1Y3QAAACm/v//FAAAAOAAAACgAQAAAAAAEZwBAAACAAAAjAAAAAQAAACE////CAAAAFgAAABNAAAAeyJ0eXBlIjoibWFwIiwia2V5VHlwZSI6InN0cmluZyIsInZhbHVlVHlwZSI6InZvaWQiLCJ2YWx1ZUNvbnRhaW5zTnVsbCI6dHJ1ZX0AAAAXAAAAU3Bhcms6RGF0YVR5cGU6SnNvblR5cGUACAAMAAgABAAIAAAACAAAABwAAAARAAAATUFQPFNUUklORywgVk9JRD4AAAAWAAAAU3Bhcms6RGF0YVR5cGU6U3FsTmFtZQAAAQAAAAQAAACW////FAAAABQAAACcAAAAAAAADZgAAAAAAAAAAgAAAFwAAAAYAAAAAAASABgAFAATABIADAAAAAgABAASAAAAFAAAABQAAAAUAAAAAAABARAAAAAAAAAAAAAAAKT///8FAAAAdmFsdWUAEgAYABQAAAATAAwAAAAIAAQAEgAAABQAAAAUAAAAFAAAAAAAAAUQAAAAAAAAAAAAAADk////AwAAAGtleQDw////BwAAAGVudHJpZXMABAAEAAQAAAAKAAAAc2FtcGxlX21hcAAA",
+   "cacheLookupResult": "CACHE_INELIGIBLE",
+   "uncompressedBytes": 464,
+   "compressedBytes": 464
+  },
+  "resultSet": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "hasMoreRows": false,
+   "results": {
+    "startRowOffset": 0,
+    "rows": [],
+    "arrowBatches": [
+     {
+      "batch": "/////3gBAAAUAAAAAAAAAAwAFgAOABUAEAAEAAwAAABQAAAAAAAAAAAABAAQAAAAAAMKABgADAAIAAQACgAAABQAAACoAAAAAQAAAAAAAAAAAAAACQAAAAAAAAAAAAAAAQAAAAAAAAAIAAAAAAAAAAgAAAAAAAAAEAAAAAAAAAABAAAAAAAAABgAAAAAAAAAAQAAAAAAAAAgAAAAAAAAAAwAAAAAAAAAMAAAAAAAAAAIAAAAAAAAADgAAAAAAAAAAQAAAAAAAABAAAAAAAAAAAEAAAAAAAAASAAAAAAAAAAIAAAAAAAAAAAAAAAJAAAAAQAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAMAAAAAAAAAAQAAAAAAAAAAAAAAAgAAAAMAAAAAAAAAAwAAAAAAAAAAAAAAAwAAAAgAAAAAAAAAcmVkZ3JlZW4BAAAAAAAAAAEAAAAAAAAAAAAAAAMAAAA=",
+      "rowCount": 1
+     }
+    ]
+   }
+  },
+  "closeOperation": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   }
+  }
+ },
+ "executionRejected": false,
+ "maxClusterCapacity": 280,
+ "queryCost": 0.5,
+ "currentClusterLoad": 1,
+ "idempotencyType": "IDEMPOTENT"
+}


### PR DESCRIPTION
Github issue #126 https://github.com/databricks/databricks-sql-go/issues/126 

Null member values in complex types (i.e. array, map, and struct) were being scanned as the zero value of the member type.
Updated column value containers for complex types to generate correct JSON for null member values. 

In cases where no type can be determined for a member an error was being thrown for an unhandled data type.
For example in the query "select map('red', NULL, 'green', NULL) as sample_map" there is no determined type for the map values. 
Added a new column value container to be created to correspond to the arrow NullType.

Updated expected values in existing list test now that null elements are no longer being treated as the zero-value of the type.

Added a new test for the case where the type of elements/members cannot be determined.

Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>