### PR TITLE
Enable Transport configuration for http client

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -214,3 +214,10 @@ func WithAuthenticator(authr auth.Authenticator) connOption {
 		c.Authenticator = authr
 	}
 }
+
+// WithTransport sets up the transport configuration to be used by the httpclient.
+func WithTransport(t http.RoundTripper) connOption {
+	return func(c *config.Config) {
+		c.Transport = t
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -319,7 +319,7 @@ func isRetryableServerResponse(resp *http.Response) bool {
 }
 
 type Transport struct {
-	Base  *http.Transport
+	Base  http.RoundTripper
 	Authr auth.Authenticator
 	trace bool
 }
@@ -396,10 +396,20 @@ func PooledClient(cfg *config.Config) *http.Client {
 	if cfg.Authenticator == nil {
 		return nil
 	}
-	tr := &Transport{
-		Base:  PooledTransport(),
-		Authr: cfg.Authenticator,
+
+	var tr *Transport
+	if cfg.Transport != nil {
+		tr = &Transport{
+			Base:  cfg.Transport,
+			Authr: cfg.Authenticator,
+		}
+	} else {
+		tr = &Transport{
+			Base:  PooledTransport(),
+			Authr: cfg.Authenticator,
+		}
 	}
+
 	return &http.Client{
 		Transport: tr,
 		Timeout:   cfg.ClientTimeout,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -97,6 +98,7 @@ type UserConfig struct {
 	RetryWaitMin   time.Duration
 	RetryWaitMax   time.Duration
 	RetryMax       int
+	Transport      http.RoundTripper
 }
 
 // DeepCopy returns a true deep copy of UserConfig
@@ -135,6 +137,7 @@ func (ucfg UserConfig) DeepCopy() UserConfig {
 		RetryWaitMin:   ucfg.RetryWaitMin,
 		RetryWaitMax:   ucfg.RetryWaitMax,
 		RetryMax:       ucfg.RetryMax,
+		Transport:      ucfg.Transport,
 	}
 }
 


### PR DESCRIPTION
### Context:
This change enables passing a RoundTripper as a configuration parameter (via the WithTransport() func) to use, for instance, a Socks5 proxy.
If the transport is not configured, it remains with the original behavior. 

### Changes made:
- Changed Transport.Base to be of interface `http.RoundTripper` (is returned as that at `PooledTransport()` ) 
- Added 'WithTransport()' func to set the transport configuration. 
- Added validation to existing test case. 