### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.2.0" // update version before each release
+var DriverVersion = "1.3.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
version 1.3.0:
Updated the retry behaviour to retry on a wider range of errors and results if the server operation is idempotent.
Bug fix for issue where complex types with a null property were not being handled correctly.
Allow for user provided authenticator.

