### PR TITLE
Bug fix for query that doesn't produce rows

### DIFF
--- a/internal/rows/arrowbased/testdata/queryVExec.json
+++ b/internal/rows/arrowbased/testdata/queryVExec.json
@@ -1,0 +1,72 @@
+{
+ "status": {
+  "statusCode": "SUCCESS_STATUS"
+ },
+ "operationHandle": {
+  "operationId": {
+   "guid": "Ae4RVsJdEj6Egpavp/LAJA==",
+   "secret": "M41SnYJyRuuEgstBlGaDnQ=="
+  },
+  "operationType": "EXECUTE_STATEMENT",
+  "hasResultSet": true
+ },
+ "directResults": {
+  "operationStatus": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "operationState": "FINISHED_STATE",
+   "operationStarted": 1687477482139,
+   "operationCompleted": 1687477484937
+  },
+  "resultSetMetadata": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "schema": {
+    "columns": [
+     {
+      "columnName": "Result",
+      "typeDesc": {
+       "types": [
+        {
+         "primitiveEntry": {
+          "type": "STRING_TYPE"
+         }
+        }
+       ]
+      },
+      "position": 1,
+      "comment": ""
+     }
+    ]
+   },
+   "resultFormat": "ARROW_BASED_SET",
+   "lz4Compressed": false,
+   "arrowSchema": "/////0AAAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAAAAAAAAAAA",
+   "cacheLookupResult": "CACHE_INELIGIBLE",
+   "uncompressedBytes": 0,
+   "compressedBytes": 0
+  },
+  "resultSet": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   },
+   "hasMoreRows": false,
+   "results": {
+    "startRowOffset": 0,
+    "rows": []
+   }
+  },
+  "closeOperation": {
+   "status": {
+    "statusCode": "SUCCESS_STATUS"
+   }
+  }
+ },
+ "executionRejected": false,
+ "maxClusterCapacity": 10,
+ "queryCost": 0,
+ "currentClusterLoad": 0,
+ "idempotencyType": "NON_IDEMPOTENT"
+}


### PR DESCRIPTION
When executing a statement that doesn't produce rows (ex. CREATE TABLE ....) using DB.Query() instead of DB.Exec() the driver would panic. When DB.Query() is used we try to create a row object.  In this case there was a mismatch in the schema metadata returned by thrift and the arrow schema metadata. The thrift schema was indicating a single column named 'Result' while the arrow schema metadata was indicating no columns. Moved the code creating the arrow schema and column info into separate functions. Updated creation of the column info to handle mismatch between the arrow and thrift schemas.  
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>