### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Release History
 
+## v1.3.1 (2023-06-23)
+
+- bug fix for panic when executing non record producing statements using DB.Query()/DB.QueryExec()
+
+## v1.3.0 (2023-06-07)
+
+- allow client provided authenticator
+- more robust retry behaviour
+- bug fix for null values in complex types
+
+## v1.2.0 (2023-04-20)
+
+- Improved error types and info
+
+## v1.1.0 (2023-03-06)
+
+- Feat: Support ability to retry on specific failures
+- Fetch results in arrow format 
+- Improve error message and retry behaviour
+
+## v1.0.1 (2023-01-05)
+
+Fixing cancel race condition 
+
+## v1.0.0 (2022-12-20)
+
+- Package doc (doc.go)
+- Handle FLOAT values as float32
+- Fix for result.AffectedRows
+- Use new ctx when closing operation after cancel 
+- Set default port to 443 
+
+## v1.0.0-rc.1 (2022-12-19)
+
+- Package doc (doc.go)
+- Handle FLOAT values as float32
+- Fix for result.AffectedRows
+- Add or edit documentation above methods
+- Tweaks to readme 
+- Use new ctx when closing operation after cancel
+
+## 0.2.2 (2022-12-12)
+
+- Handle parsing negative years in dates
+- fix thread safety issue 
+
+## 0.2.1 (2022-12-05)
+
+- Don't ignore error in InitThriftClient 
+- Close optimization for Rows 
+- Close operation after executing statement
+- Minor change to examples
+- P&R improvements 
+
 ## 0.1.x (Unreleased)
 
 - Fix thread safety issue in connector

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.3.0" // update version before each release
+var DriverVersion = "1.3.1" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
- Update version and changelog
- 1.3.1 contains a bug fix for queries that don't produce a result set
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>