### PR TITLE
Improve error information when query terminates in unexpected state.

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -161,7 +161,7 @@ func TestConn_executeStatement(t *testing.T) {
 			if opTest.err == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, "databricks: execution error: failed to execute query: "+opTest.err)
+				assert.EqualError(t, err, "databricks: execution error: failed to execute query: unexpected operation state "+opTest.state.String()+": "+opTest.err)
 			}
 			assert.Equal(t, 1, executeStatementCount)
 			assert.Equal(t, opTest.closeOperationCount, closeOperationCount)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -12,7 +13,6 @@ const (
 	ErrNotImplemented           = "not implemented"
 	ErrTransactionsNotSupported = "transactions are not supported"
 	ErrParametersNotSupported   = "query parameters are not supported"
-	ErrInvalidOperationState    = "invalid operation state. This should not have happened"
 	ErrReadQueryStatus          = "could not read query status"
 	ErrSentinelTimeout          = "sentinel timed out waiting for operation to complete"
 
@@ -32,6 +32,14 @@ const (
 	// Execution error messages (query failure)
 	ErrQueryExecution = "failed to execute query"
 )
+
+func ErrInvalidOperationState(state string) string {
+	return fmt.Sprintf("invalid operation state %s. This should not have happened", state)
+}
+
+func ErrUnexpectedOperationState(state string) string {
+	return fmt.Sprintf("unexpected operation state %s", state)
+}
 
 // value to be used with errors.Is() to determine if an error chain contains a request error
 var RequestError error = errors.New("Request Error")


### PR DESCRIPTION
When a query terminated in either an unknown or an unexpected operation state the connection was creating a driver error with a static message. 
Updated to include the operation state in the error message for an unknown operation state situation. 
Updated the case of an unexpected operation state to include the state and the operation status display message. 
Updated unit tests based on the new error message.
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>