### PR TITLE
Cloudfetch expired links

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -287,8 +287,8 @@ func (c *conn) executeStatement(ctx context.Context, query string, args []driver
 		}
 	}
 
-	if c.cfg.EnableCloudFetch {
-		req.CanDownloadResult_ = &c.cfg.EnableCloudFetch
+	if c.cfg.UseCloudFetch {
+		req.CanDownloadResult_ = &c.cfg.UseCloudFetch
 	}
 
 	ctx = driverctx.NewContextWithConnId(ctx, c.id)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -31,6 +31,7 @@ const (
 
 	// Execution error messages (query failure)
 	ErrQueryExecution = "failed to execute query"
+	ErrLinkExpired    = "link expired"
 )
 
 // value to be used with errors.Is() to determine if an error chain contains a request error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -314,14 +314,14 @@ func (arrowConfig ArrowConfig) DeepCopy() ArrowConfig {
 }
 
 type CloudFetchConfig struct {
-	EnableCloudFetch   bool
+	UseCloudFetch      bool
 	MaxDownloadThreads int
 	MaxFilesInMemory   int
 	MinTimeToExpiry    time.Duration
 }
 
 func (cfg CloudFetchConfig) WithDefaults() CloudFetchConfig {
-	cfg.EnableCloudFetch = false
+	cfg.UseCloudFetch = false
 
 	if cfg.MaxDownloadThreads <= 0 {
 		cfg.MaxDownloadThreads = 10
@@ -340,7 +340,7 @@ func (cfg CloudFetchConfig) WithDefaults() CloudFetchConfig {
 
 func (cfg CloudFetchConfig) DeepCopy() CloudFetchConfig {
 	return CloudFetchConfig{
-		EnableCloudFetch:   cfg.EnableCloudFetch,
+		UseCloudFetch:      cfg.UseCloudFetch,
 		MaxDownloadThreads: cfg.MaxDownloadThreads,
 		MaxFilesInMemory:   cfg.MaxFilesInMemory,
 		MinTimeToExpiry:    cfg.MinTimeToExpiry,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,7 @@ type UserConfig struct {
 	RetryMax          int
 	UseLz4Compression bool
 	EnableCloudFetch  bool
+	LinkExpiryBuffer  time.Duration
 }
 
 // DeepCopy returns a true deep copy of UserConfig
@@ -139,6 +140,7 @@ func (ucfg UserConfig) DeepCopy() UserConfig {
 		RetryMax:          ucfg.RetryMax,
 		UseLz4Compression: ucfg.UseLz4Compression,
 		EnableCloudFetch:  ucfg.EnableCloudFetch,
+		LinkExpiryBuffer: ucfg.LinkExpiryBuffer,
 	}
 }
 
@@ -173,6 +175,7 @@ func (ucfg UserConfig) WithDefaults() UserConfig {
 	}
 	ucfg.UseLz4Compression = false
 	ucfg.EnableCloudFetch = false
+	ucfg.LinkExpiryBuffer = 0 * time.Second
 
 	return ucfg
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	UserConfig
 	TLSConfig *tls.Config // nil disables TLS
 	ArrowConfig
+	CloudFetchConfig
 	RunAsync                  bool // TODO
 	PollInterval              time.Duration
 	ClientTimeout             time.Duration // max time the http request can last
@@ -98,8 +99,6 @@ type UserConfig struct {
 	RetryWaitMax      time.Duration
 	RetryMax          int
 	UseLz4Compression bool
-	EnableCloudFetch  bool
-	LinkExpiryBuffer  time.Duration
 }
 
 // DeepCopy returns a true deep copy of UserConfig
@@ -139,8 +138,6 @@ func (ucfg UserConfig) DeepCopy() UserConfig {
 		RetryWaitMax:      ucfg.RetryWaitMax,
 		RetryMax:          ucfg.RetryMax,
 		UseLz4Compression: ucfg.UseLz4Compression,
-		EnableCloudFetch:  ucfg.EnableCloudFetch,
-		LinkExpiryBuffer: ucfg.LinkExpiryBuffer,
 	}
 }
 
@@ -174,8 +171,6 @@ func (ucfg UserConfig) WithDefaults() UserConfig {
 		ucfg.RetryWaitMax = 30 * time.Second
 	}
 	ucfg.UseLz4Compression = false
-	ucfg.EnableCloudFetch = false
-	ucfg.LinkExpiryBuffer = 0 * time.Second
 
 	return ucfg
 }
@@ -186,6 +181,7 @@ func WithDefaults() *Config {
 		UserConfig:                UserConfig{}.WithDefaults(),
 		TLSConfig:                 &tls.Config{MinVersion: tls.VersionTLS12},
 		ArrowConfig:               ArrowConfig{}.WithDefaults(),
+		CloudFetchConfig:          CloudFetchConfig{}.WithDefaults(),
 		RunAsync:                  true,
 		PollInterval:              1 * time.Second,
 		ClientTimeout:             900 * time.Second,
@@ -314,5 +310,39 @@ func (arrowConfig ArrowConfig) DeepCopy() ArrowConfig {
 		UseArrowNativeTimestamp:     arrowConfig.UseArrowNativeTimestamp,
 		UseArrowNativeComplexTypes:  arrowConfig.UseArrowNativeComplexTypes,
 		UseArrowNativeIntervalTypes: arrowConfig.UseArrowNativeIntervalTypes,
+	}
+}
+
+type CloudFetchConfig struct {
+	EnableCloudFetch   bool
+	MaxDownloadThreads int
+	MaxFilesInMemory   int
+	MinTimeToExpiry    time.Duration
+}
+
+func (cfg CloudFetchConfig) WithDefaults() CloudFetchConfig {
+	cfg.EnableCloudFetch = false
+
+	if cfg.MaxDownloadThreads <= 0 {
+		cfg.MaxDownloadThreads = 10
+	}
+
+	if cfg.MaxFilesInMemory < 1 {
+		cfg.MaxFilesInMemory = 10
+	}
+
+	if cfg.MinTimeToExpiry < 0 {
+		cfg.MinTimeToExpiry = 0 * time.Second
+	}
+
+	return cfg
+}
+
+func (cfg CloudFetchConfig) DeepCopy() CloudFetchConfig {
+	return CloudFetchConfig{
+		EnableCloudFetch:   cfg.EnableCloudFetch,
+		MaxDownloadThreads: cfg.MaxDownloadThreads,
+		MaxFilesInMemory:   cfg.MaxFilesInMemory,
+		MinTimeToExpiry:    cfg.MinTimeToExpiry,
 	}
 }

--- a/internal/rows/arrowbased/batchloader.go
+++ b/internal/rows/arrowbased/batchloader.go
@@ -25,7 +25,7 @@ type cloudURL struct {
 }
 
 func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArrowBatch, error) {
-	if isLinkExpired(cu.ExpiryTime, cfg.LinkExpiryBuffer) {
+	if isLinkExpired(cu.ExpiryTime, cfg.MinTimeToExpiry) {
 		return nil, errors.New(dbsqlerr.ErrLinkExpired)
 	}
 

--- a/internal/rows/arrowbased/batchloader.go
+++ b/internal/rows/arrowbased/batchloader.go
@@ -25,7 +25,7 @@ type cloudURL struct {
 }
 
 func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArrowBatch, error) {
-	if isLinkExpired(cu.ExpiryTime) {
+	if isLinkExpired(cu.ExpiryTime, cfg.LinkExpiryBuffer) {
 		return nil, errors.New(dbsqlerr.ErrLinkExpired)
 	}
 
@@ -95,8 +95,9 @@ func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArro
 	return arrowBatches, nil
 }
 
-func isLinkExpired(expiryTime int64) bool {
-	return expiryTime < time.Now().Unix()
+func isLinkExpired(expiryTime int64, linkExpiryBuffer time.Duration) bool {
+	bufferSecs := int64(linkExpiryBuffer.Seconds())
+	return expiryTime-bufferSecs < time.Now().Unix()
 }
 
 func getArrowReader(rd io.Reader, useLz4Compression bool) (*ipc.Reader, error) {


### PR DESCRIPTION
Throw error for expired cloud fetch links. For now, no special handling or retries.