### PR TITLE
Allow WithServerHostname to specify protocol

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -109,11 +109,35 @@ func withUserConfig(ucfg config.UserConfig) connOption {
 // WithServerHostname sets up the server hostname. Mandatory.
 func WithServerHostname(host string) connOption {
 	return func(c *config.Config) {
-		if host == "localhost" {
-			c.Protocol = "http"
+		protocol, hostname := parseHostName(host)
+		if protocol != "" {
+			c.Protocol = protocol
 		}
-		c.Host = host
+
+		c.Host = hostname
 	}
+}
+
+func parseHostName(host string) (protocol, hostname string) {
+	hostname = host
+	if strings.HasPrefix(host, "https") {
+		hostname = strings.TrimPrefix(host, "https")
+		protocol = "https"
+	} else if strings.HasPrefix(host, "http") {
+		hostname = strings.TrimPrefix(host, "http")
+		protocol = "http"
+	}
+
+	if protocol != "" {
+		hostname = strings.TrimPrefix(hostname, ":")
+		hostname = strings.TrimPrefix(hostname, "//")
+	}
+
+	if hostname == "localhost" && protocol == "" {
+		protocol = "http"
+	}
+
+	return
 }
 
 // WithPort sets up the server port. Mandatory.

--- a/connector_test.go
+++ b/connector_test.go
@@ -130,6 +130,37 @@ func TestNewConnector(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedCfg, coni.cfg)
 	})
+
+	t.Run("Connector test WithServerHostname", func(t *testing.T) {
+		cases := []struct {
+			hostname, host, protocol string
+		}{
+			{"databricks-host", "databricks-host", "https"},
+			{"http://databricks-host", "databricks-host", "http"},
+			{"https://databricks-host", "databricks-host", "https"},
+			{"http:databricks-host", "databricks-host", "http"},
+			{"https:databricks-host", "databricks-host", "https"},
+			{"htt://databricks-host", "htt://databricks-host", "https"},
+			{"localhost", "localhost", "http"},
+			{"http:localhost", "localhost", "http"},
+			{"https:localhost", "localhost", "https"},
+		}
+
+		for i := range cases {
+			c := cases[i]
+			con, err := NewConnector(
+				WithServerHostname(c.hostname),
+			)
+			assert.Nil(t, err)
+
+			coni, ok := con.(*connector)
+			require.True(t, ok)
+			userConfig := coni.cfg.UserConfig
+			require.Equal(t, c.protocol, userConfig.Protocol)
+			require.Equal(t, c.host, userConfig.Host)
+		}
+
+	})
 }
 
 type mockRoundTripper struct{}

--- a/doc.go
+++ b/doc.go
@@ -70,7 +70,7 @@ Use sql.OpenDB() to create a database handle via a new connector object created 
 
 Supported functional options include:
 
-  - WithServerHostname(<hostname> string): Sets up the server hostname. Mandatory
+  - WithServerHostname(<hostname> string): Sets up the server hostname. The hostname can be prefixed with "http:" or "https:" to specify a protocol to use. Mandatory
   - WithPort(<port> int): Sets up the server port. Mandatory
   - WithAccessToken(<my_token> string): Sets up the Personal Access Token. Mandatory
   - WithHTTPPath(<http_path> string): Sets up the endpoint to the warehouse. Mandatory


### PR DESCRIPTION
Updated WithServerHostname to allow prefixing the hostname with 'https:' or 'http:' to specify which protocol to use. Github issue #140
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>