### PR TITLE
PECO-1054 Expose Arrow batches to users

### DIFF
--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -2,11 +2,11 @@ package fetcher
 
 import (
 	"context"
-	"github.com/databricks/databricks-sql-go/internal/config"
-	"github.com/pkg/errors"
 	"math"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // Create a mock struct for FetchableItems
@@ -20,7 +20,7 @@ type mockOutput struct {
 }
 
 // Implement the Fetch method
-func (m *mockFetchableItem) Fetch(ctx context.Context, cfg *config.Config) ([]*mockOutput, error) {
+func (m *mockFetchableItem) Fetch(ctx context.Context) ([]*mockOutput, error) {
 	time.Sleep(m.wait)
 	outputs := make([]*mockOutput, 5)
 	for i := range outputs {
@@ -35,7 +35,7 @@ var _ FetchableItems[*mockOutput] = (*mockFetchableItem)(nil)
 func TestConcurrentFetcher(t *testing.T) {
 	t.Run("Comprehensively tests the concurrent fetcher", func(t *testing.T) {
 		ctx := context.Background()
-		cfg := &config.Config{}
+
 		inputChan := make(chan FetchableItems[*mockOutput], 10)
 		for i := 0; i < 10; i++ {
 			item := mockFetchableItem{item: i, wait: 1 * time.Second}
@@ -44,7 +44,7 @@ func TestConcurrentFetcher(t *testing.T) {
 		close(inputChan)
 
 		// Create a fetcher
-		fetcher, err := NewConcurrentFetcher[*mockFetchableItem](ctx, 3, cfg, inputChan)
+		fetcher, err := NewConcurrentFetcher[*mockFetchableItem](ctx, 3, 3, inputChan)
 		if err != nil {
 			t.Fatalf("Error creating fetcher: %v", err)
 		}
@@ -95,7 +95,7 @@ func TestConcurrentFetcher(t *testing.T) {
 		close(inputChan)
 
 		// Create a new fetcher
-		fetcher, err := NewConcurrentFetcher[*mockFetchableItem](ctx, 2, &config.Config{}, inputChan)
+		fetcher, err := NewConcurrentFetcher[*mockFetchableItem](ctx, 2, 2, inputChan)
 		if err != nil {
 			t.Fatalf("Error creating fetcher: %v", err)
 		}

--- a/internal/rows/arrowbased/arrowRows_test.go
+++ b/internal/rows/arrowbased/arrowRows_test.go
@@ -663,7 +663,7 @@ func TestArrowRowScanner(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, lastReadBatch)
 			assert.Equal(t, 1, callCount)
-			assert.Equal(t, int64(0), lastReadBatch.startRow)
+			assert.Equal(t, int64(0), lastReadBatch.Start())
 		}
 
 		for _, i := range []int64{5, 6, 7} {
@@ -671,7 +671,7 @@ func TestArrowRowScanner(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, lastReadBatch)
 			assert.Equal(t, 2, callCount)
-			assert.Equal(t, int64(5), lastReadBatch.startRow)
+			assert.Equal(t, int64(5), lastReadBatch.Start())
 		}
 
 		for _, i := range []int64{8, 9, 10, 11, 12, 13, 14} {
@@ -679,7 +679,7 @@ func TestArrowRowScanner(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, lastReadBatch)
 			assert.Equal(t, 3, callCount)
-			assert.Equal(t, int64(8), lastReadBatch.startRow)
+			assert.Equal(t, int64(8), lastReadBatch.Start())
 		}
 
 		err := ars.loadBatchFor(-1)
@@ -983,13 +983,13 @@ func TestArrowRowScanner(t *testing.T) {
 
 			if i%1000 == 0 {
 				assert.NotNil(t, ars.currentBatch)
-				assert.Equal(t, int64(i), ars.currentBatch.startRow)
+				assert.Equal(t, int64(i), ars.currentBatch.Start())
 				if i < 53000 {
-					assert.Equal(t, int64(1000), ars.currentBatch.rowCount)
+					assert.Equal(t, int64(1000), ars.currentBatch.Count())
 				} else {
-					assert.Equal(t, int64(940), ars.currentBatch.rowCount)
+					assert.Equal(t, int64(940), ars.currentBatch.Count())
 				}
-				assert.Equal(t, ars.currentBatch.startRow+ars.currentBatch.rowCount-1, ars.currentBatch.endRow)
+				assert.Equal(t, ars.currentBatch.Start()+ars.currentBatch.Count()-1, ars.currentBatch.End())
 			}
 		}
 

--- a/internal/rows/arrowbased/batchloader.go
+++ b/internal/rows/arrowbased/batchloader.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"github.com/databricks/databricks-sql-go/internal/config"
-	"github.com/pierrec/lz4/v4"
-	"github.com/pkg/errors"
 	"io"
 	"time"
+
+	"github.com/databricks/databricks-sql-go/internal/config"
+	"github.com/databricks/databricks-sql-go/internal/rows/rowscanner"
+	"github.com/pierrec/lz4/v4"
+	"github.com/pkg/errors"
 
 	"net/http"
 
@@ -20,12 +22,120 @@ import (
 	"github.com/databricks/databricks-sql-go/internal/fetcher"
 )
 
-type cloudURL struct {
-	*cli_service.TSparkArrowResultLink
+type BatchLoader interface {
+	GetBatchFor(recordNum int64) (*sparkArrowBatch, dbsqlerr.DBError)
 }
 
-func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArrowBatch, error) {
-	if isLinkExpired(cu.ExpiryTime, cfg.MinTimeToExpiry) {
+func NewCloudBatchLoader(ctx context.Context, files []*cli_service.TSparkArrowResultLink, cfg *config.Config) (*batchLoader[*cloudURL], dbsqlerr.DBError) {
+
+	if cfg == nil {
+		cfg = config.WithDefaults()
+	}
+
+	inputChan := make(chan fetcher.FetchableItems[*sparkArrowBatch], len(files))
+
+	for i := range files {
+		li := &cloudURL{
+			TSparkArrowResultLink: files[i],
+			minTimeToExpiry:       cfg.MinTimeToExpiry,
+			useLz4Compression:     cfg.UseLz4Compression,
+		}
+		inputChan <- li
+	}
+
+	// make sure to close input channel or fetcher will block waiting for more inputs
+	close(inputChan)
+
+	f, _ := fetcher.NewConcurrentFetcher[*cloudURL](ctx, cfg.MaxDownloadThreads, cfg.MaxFilesInMemory, inputChan)
+	cbl := &batchLoader[*cloudURL]{
+		Fetcher: f,
+		ctx:     ctx,
+	}
+
+	return cbl, nil
+}
+
+func NewLocalBatchLoader(ctx context.Context, batches []*cli_service.TSparkArrowBatch, cfg *config.Config) (*batchLoader[*localBatch], dbsqlerr.DBError) {
+
+	if cfg == nil {
+		cfg = config.WithDefaults()
+	}
+
+	var startRow int64
+	inputChan := make(chan fetcher.FetchableItems[*sparkArrowBatch], len(batches))
+	for i := range batches {
+		b := batches[i]
+		if b != nil {
+			li := &localBatch{
+				TSparkArrowBatch:  b,
+				startRow:          startRow,
+				useLz4Compression: cfg.UseLz4Compression,
+			}
+			inputChan <- li
+			startRow = startRow + b.RowCount
+		}
+	}
+	close(inputChan)
+
+	f, _ := fetcher.NewConcurrentFetcher[*localBatch](ctx, cfg.MaxDownloadThreads, cfg.MaxFilesInMemory, inputChan)
+	cbl := &batchLoader[*localBatch]{
+		Fetcher: f,
+		ctx:     ctx,
+	}
+
+	return cbl, nil
+}
+
+type batchLoader[T interface {
+	Fetch(ctx context.Context) ([]*sparkArrowBatch, error)
+}] struct {
+	fetcher.Fetcher[*sparkArrowBatch]
+	arrowBatches []*sparkArrowBatch
+	ctx          context.Context
+}
+
+var _ BatchLoader = (*batchLoader[*localBatch])(nil)
+
+func (cbl *batchLoader[T]) GetBatchFor(recordNum int64) (*sparkArrowBatch, dbsqlerr.DBError) {
+
+	for i := range cbl.arrowBatches {
+		if cbl.arrowBatches[i].Start() <= recordNum && cbl.arrowBatches[i].End() >= recordNum {
+			return cbl.arrowBatches[i], nil
+		}
+	}
+
+	batchChan, _, err := cbl.Start()
+	if err != nil {
+		return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
+	}
+
+	for {
+		batch, ok := <-batchChan
+		if !ok {
+			err := cbl.Err()
+			if err != nil {
+				return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
+			}
+			break
+		}
+
+		cbl.arrowBatches = append(cbl.arrowBatches, batch)
+		if batch.Contains(recordNum) {
+			return batch, nil
+		}
+	}
+
+	return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
+}
+
+type cloudURL struct {
+	*cli_service.TSparkArrowResultLink
+	minTimeToExpiry   time.Duration
+	useLz4Compression bool
+}
+
+func (cu *cloudURL) Fetch(ctx context.Context) ([]*sparkArrowBatch, error) {
+	if isLinkExpired(cu.ExpiryTime, cu.minTimeToExpiry) {
 		return nil, errors.New(dbsqlerr.ErrLinkExpired)
 	}
 
@@ -48,7 +158,7 @@ func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArro
 	var arrowSchema *arrow.Schema
 	var arrowBatches []*sparkArrowBatch
 
-	rdr, err := getArrowReader(res.Body, cfg.UseLz4Compression)
+	rdr, err := getArrowReader(res.Body, cu.useLz4Compression)
 
 	if err != nil {
 		return nil, err
@@ -78,11 +188,9 @@ func (cu *cloudURL) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArro
 		recordBytes := output.Bytes()
 
 		arrowBatches = append(arrowBatches, &sparkArrowBatch{
+			Delimiter:        rowscanner.NewDelimiter(startRow, r.NumRows()),
 			arrowRecordBytes: recordBytes,
 			hasSchema:        true,
-			rowCount:         r.NumRows(),
-			startRow:         startRow,
-			endRow:           startRow + r.NumRows() - 1,
 		})
 
 		startRow = startRow + r.NumRows()
@@ -130,108 +238,21 @@ var _ fetcher.FetchableItems[*sparkArrowBatch] = (*cloudURL)(nil)
 
 type localBatch struct {
 	*cli_service.TSparkArrowBatch
-	startRow int64
+	startRow          int64
+	useLz4Compression bool
 }
 
 var _ fetcher.FetchableItems[*sparkArrowBatch] = (*localBatch)(nil)
 
-func (lb *localBatch) Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArrowBatch, error) {
-	arrowBatchBytes, err := getArrowBatch(cfg.UseLz4Compression, lb.Batch)
+func (lb *localBatch) Fetch(ctx context.Context) ([]*sparkArrowBatch, error) {
+	arrowBatchBytes, err := getArrowBatch(lb.useLz4Compression, lb.Batch)
 	if err != nil {
 		return nil, err
 	}
 	batch := &sparkArrowBatch{
-		rowCount:         lb.RowCount,
-		startRow:         lb.startRow,
-		endRow:           lb.startRow + lb.RowCount - 1,
+		Delimiter:        rowscanner.NewDelimiter(lb.startRow, lb.RowCount),
 		arrowRecordBytes: arrowBatchBytes,
 	}
 
 	return []*sparkArrowBatch{batch}, nil
-}
-
-type BatchLoader interface {
-	GetBatchFor(recordNum int64) (*sparkArrowBatch, dbsqlerr.DBError)
-}
-
-type batchLoader[T interface {
-	Fetch(ctx context.Context, cfg *config.Config) ([]*sparkArrowBatch, error)
-}] struct {
-	fetcher.Fetcher[*sparkArrowBatch]
-	arrowBatches []*sparkArrowBatch
-	ctx          context.Context
-}
-
-func NewCloudBatchLoader(ctx context.Context, files []*cli_service.TSparkArrowResultLink, cfg *config.Config) (*batchLoader[*cloudURL], dbsqlerr.DBError) {
-	inputChan := make(chan fetcher.FetchableItems[*sparkArrowBatch], len(files))
-
-	for i := range files {
-		li := &cloudURL{TSparkArrowResultLink: files[i]}
-		inputChan <- li
-	}
-
-	// make sure to close input channel or fetcher will block waiting for more inputs
-	close(inputChan)
-
-	f, _ := fetcher.NewConcurrentFetcher[*cloudURL](ctx, 3, cfg, inputChan)
-	cbl := &batchLoader[*cloudURL]{
-		Fetcher: f,
-		ctx:     ctx,
-	}
-
-	return cbl, nil
-}
-
-func NewLocalBatchLoader(ctx context.Context, batches []*cli_service.TSparkArrowBatch, cfg *config.Config) (*batchLoader[*localBatch], dbsqlerr.DBError) {
-	var startRow int64
-	inputChan := make(chan fetcher.FetchableItems[*sparkArrowBatch], len(batches))
-	for i := range batches {
-		b := batches[i]
-		if b != nil {
-			li := &localBatch{TSparkArrowBatch: b, startRow: startRow}
-			inputChan <- li
-			startRow = startRow + b.RowCount
-		}
-	}
-	close(inputChan)
-
-	f, _ := fetcher.NewConcurrentFetcher[*localBatch](ctx, 3, cfg, inputChan)
-	cbl := &batchLoader[*localBatch]{
-		Fetcher: f,
-		ctx:     ctx,
-	}
-
-	return cbl, nil
-}
-
-func (cbl *batchLoader[T]) GetBatchFor(recordNum int64) (*sparkArrowBatch, dbsqlerr.DBError) {
-
-	for i := range cbl.arrowBatches {
-		if cbl.arrowBatches[i].startRow <= recordNum && cbl.arrowBatches[i].endRow >= recordNum {
-			return cbl.arrowBatches[i], nil
-		}
-	}
-
-	batchChan, _, err := cbl.Start()
-	if err != nil {
-		return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
-	}
-
-	for {
-		batch, ok := <-batchChan
-		if !ok {
-			err := cbl.Err()
-			if err != nil {
-				return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
-			}
-			break
-		}
-
-		cbl.arrowBatches = append(cbl.arrowBatches, batch)
-		if batch.contains(recordNum) {
-			return batch, nil
-		}
-	}
-
-	return nil, dbsqlerrint.NewDriverError(cbl.ctx, errArrowRowsInvalidRowIndex(recordNum), err)
 }

--- a/internal/rows/columnbased/columnRows.go
+++ b/internal/rows/columnbased/columnRows.go
@@ -22,11 +22,9 @@ type columnRowScanner struct {
 	rowSet *cli_service.TRowSet
 	schema *cli_service.TTableSchema
 
-	// number of rows in the current TRowSet
-	nRows int64
-
 	location *time.Location
 	ctx      context.Context
+	rowscanner.Delimiter
 }
 
 var _ rowscanner.RowScanner = (*columnRowScanner)(nil)
@@ -47,9 +45,9 @@ func NewColumnRowScanner(schema *cli_service.TTableSchema, rowSet *cli_service.T
 
 	logger.Debug().Msg("databricks: creating column row scanner")
 	rs := &columnRowScanner{
+		Delimiter:   rowscanner.NewDelimiter(rowSet.StartRowOffset, rowscanner.CountRows(rowSet)),
 		schema:      schema,
 		rowSet:      rowSet,
-		nRows:       countRows(rowSet),
 		DBSQLLogger: logger,
 		location:    location,
 		ctx:         ctx,
@@ -66,7 +64,7 @@ func (crs *columnRowScanner) NRows() int64 {
 	if crs == nil {
 		return 0
 	}
-	return crs.nRows
+	return crs.Count()
 }
 
 // ScanRow is called to populate the provided slice with the
@@ -136,40 +134,4 @@ func (crs *columnRowScanner) value(tColumn *cli_service.TColumn, tColumnDesc *cl
 	}
 
 	return val, err
-}
-
-// countRows returns the number of rows in the TRowSet
-func countRows(rowSet *cli_service.TRowSet) int64 {
-	if rowSet == nil || rowSet.Columns == nil {
-		return 0
-	}
-
-	// Find a column/values and return the number of values.
-	for _, col := range rowSet.Columns {
-		if col.BoolVal != nil {
-			return int64(len(col.BoolVal.Values))
-		}
-		if col.ByteVal != nil {
-			return int64(len(col.ByteVal.Values))
-		}
-		if col.I16Val != nil {
-			return int64(len(col.I16Val.Values))
-		}
-		if col.I32Val != nil {
-			return int64(len(col.I32Val.Values))
-		}
-		if col.I64Val != nil {
-			return int64(len(col.I64Val.Values))
-		}
-		if col.StringVal != nil {
-			return int64(len(col.StringVal.Values))
-		}
-		if col.DoubleVal != nil {
-			return int64(len(col.DoubleVal.Values))
-		}
-		if col.BinaryVal != nil {
-			return int64(len(col.BinaryVal.Values))
-		}
-	}
-	return 0
 }

--- a/internal/rows/errors.go
+++ b/internal/rows/errors.go
@@ -2,18 +2,12 @@ package rows
 
 import "fmt"
 
-var errRowsFetchPriorToStart = "databricks: unable to fetch row page prior to start of results"
 var errRowsNoClient = "databricks: instance of Rows missing client"
 var errRowsNilRows = "databricks: nil Rows instance"
 var errRowsUnknowRowType = "databricks: unknown rows representation"
 var errRowsCloseFailed = "databricks: Rows instance Close operation failed"
 var errRowsMetadataFetchFailed = "databricks: Rows instance failed to retrieve result set metadata"
-var errRowsResultFetchFailed = "databricks: Rows instance failed to retrieve results"
 
 func errRowsInvalidColumnIndex(index int) string {
 	return fmt.Sprintf("databricks: invalid column index: %d", index)
-}
-
-func errRowsUnandledFetchDirection(dir string) string {
-	return fmt.Sprintf("databricks: unhandled fetch direction %s", dir)
 }

--- a/internal/rows/rowscanner/resultPageIterator.go
+++ b/internal/rows/rowscanner/resultPageIterator.go
@@ -1,0 +1,240 @@
+package rowscanner
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/databricks/databricks-sql-go/driverctx"
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	dbsqlerrint "github.com/databricks/databricks-sql-go/internal/errors"
+	dbsqllog "github.com/databricks/databricks-sql-go/logger"
+)
+
+var errRowsResultFetchFailed = "databricks: Rows instance failed to retrieve results"
+var ErrRowsFetchPriorToStart = "databricks: unable to fetch row page prior to start of results"
+var errRowsNilResultPageFetcher = "databricks: nil ResultPageFetcher instance"
+
+func errRowsUnandledFetchDirection(dir string) string {
+	return fmt.Sprintf("databricks: unhandled fetch direction %s", dir)
+}
+
+// Interface for iterating over the pages in the result set of a query
+type ResultPageIterator interface {
+	Next() (*cli_service.TFetchResultsResp, error)
+	HasNext() bool
+	Delimiter
+}
+
+// Define directions for seeking in the pages of a query result
+type Direction int
+
+const (
+	DirUnknown Direction = iota
+	DirNone
+	DirForward
+	DirBack
+)
+
+var directionNames []string = []string{"Unknown", "None", "Forward", "Back"}
+
+func (d Direction) String() string {
+	return directionNames[d]
+}
+
+// Create a new result page iterator.
+func NewResultPageIterator(
+	delimiter Delimiter,
+	hasMoreRows bool,
+	maxPageSize int64,
+	opHandle *cli_service.TOperationHandle,
+	client cli_service.TCLIService,
+	connectionId string,
+	correlationId string,
+	logger *dbsqllog.DBSQLLogger,
+) ResultPageIterator {
+	// delimiter and hasMoreRows are used to set up the point in the paginated
+	// result set that this iterator starts from.
+	return &resultPageIterator{
+		Delimiter:     delimiter,
+		isFinished:    !hasMoreRows,
+		maxPageSize:   maxPageSize,
+		opHandle:      opHandle,
+		client:        client,
+		connectionId:  connectionId,
+		correlationId: correlationId,
+		logger:        logger,
+	}
+}
+
+type resultPageIterator struct {
+	// Gives the parameters of the current result page
+	Delimiter
+
+	//	indicates whether there are any more pages in the result set
+	isFinished bool
+
+	// max number of rows to fetch in a page
+	maxPageSize int64
+
+	// handle of the operation producing the result set
+	opHandle *cli_service.TOperationHandle
+
+	// client for communicating with the server
+	client cli_service.TCLIService
+
+	// connectionId to include in logging messages
+	connectionId string
+
+	// user provided value to include in logging messages
+	correlationId string
+
+	logger *dbsqllog.DBSQLLogger
+}
+
+var _ ResultPageIterator = (*resultPageIterator)(nil)
+
+// Returns true if there are more pages in the result set.
+func (rpf *resultPageIterator) HasNext() bool { return !rpf.isFinished }
+
+// Returns the next page of the result set. io.EOF will be returned if there are
+// no more pages.
+func (rpf *resultPageIterator) Next() (*cli_service.TFetchResultsResp, error) {
+
+	if rpf == nil {
+		return nil, dbsqlerrint.NewDriverError(context.Background(), errRowsNilResultPageFetcher, nil)
+	}
+
+	if rpf.isFinished {
+		return nil, io.EOF
+	}
+
+	// Starting row number of next result pag. This is used to check that the returned page is
+	// the expected one.
+	nextPageStartRow := rpf.Start() + rpf.Count()
+
+	rpf.logger.Debug().Msgf("databricks: fetching result page for row %d", nextPageStartRow)
+	ctx := driverctx.NewContextWithCorrelationId(driverctx.NewContextWithConnId(context.Background(), rpf.connectionId), rpf.correlationId)
+
+	// Keep fetching in the appropriate direction until we have the expected page.
+	var fetchResult *cli_service.TFetchResultsResp
+	var b bool
+	for b = rpf.Contains(nextPageStartRow); !b; b = rpf.Contains(nextPageStartRow) {
+
+		direction := rpf.Direction(nextPageStartRow)
+		err := rpf.checkDirectionValid(ctx, direction)
+		if err != nil {
+			return nil, err
+		}
+
+		rpf.logger.Debug().Msgf("fetching next batch of up to %d rows, %s", rpf.maxPageSize, direction.String())
+
+		var includeResultSetMetadata = true
+		req := cli_service.TFetchResultsReq{
+			OperationHandle:          rpf.opHandle,
+			MaxRows:                  rpf.maxPageSize,
+			Orientation:              directionToSparkDirection(direction),
+			IncludeResultSetMetadata: &includeResultSetMetadata,
+		}
+
+		fetchResult, err = rpf.client.FetchResults(ctx, &req)
+		if err != nil {
+			rpf.logger.Err(err).Msg("databricks: Rows instance failed to retrieve results")
+			return nil, dbsqlerrint.NewRequestError(ctx, errRowsResultFetchFailed, err)
+		}
+
+		rpf.Delimiter = NewDelimiter(fetchResult.Results.StartRowOffset, CountRows(fetchResult.Results))
+		if fetchResult.HasMoreRows != nil {
+			rpf.isFinished = !*fetchResult.HasMoreRows
+		} else {
+			rpf.isFinished = true
+		}
+		rpf.logger.Debug().Msgf("databricks: new result page startRow: %d, nRows: %v, hasMoreRows: %v", rpf.Start(), rpf.Count(), fetchResult.HasMoreRows)
+	}
+
+	return fetchResult, nil
+}
+
+// countRows returns the number of rows in the TRowSet
+func CountRows(rowSet *cli_service.TRowSet) int64 {
+	if rowSet == nil {
+		return 0
+	}
+
+	if rowSet.ArrowBatches != nil {
+		batches := rowSet.ArrowBatches
+		var n int64
+		for i := range batches {
+			n += batches[i].RowCount
+		}
+		return n
+	}
+
+	if rowSet.ResultLinks != nil {
+		links := rowSet.ResultLinks
+		var n int64
+		for i := range links {
+			n += links[i].RowCount
+		}
+		return n
+	}
+
+	if rowSet != nil && rowSet.Columns != nil {
+		// Find a column/values and return the number of values.
+		for _, col := range rowSet.Columns {
+			if col.BoolVal != nil {
+				return int64(len(col.BoolVal.Values))
+			}
+			if col.ByteVal != nil {
+				return int64(len(col.ByteVal.Values))
+			}
+			if col.I16Val != nil {
+				return int64(len(col.I16Val.Values))
+			}
+			if col.I32Val != nil {
+				return int64(len(col.I32Val.Values))
+			}
+			if col.I64Val != nil {
+				return int64(len(col.I64Val.Values))
+			}
+			if col.StringVal != nil {
+				return int64(len(col.StringVal.Values))
+			}
+			if col.DoubleVal != nil {
+				return int64(len(col.DoubleVal.Values))
+			}
+			if col.BinaryVal != nil {
+				return int64(len(col.BinaryVal.Values))
+			}
+		}
+	}
+	return 0
+}
+
+// Check if trying to fetch in the specified direction creates an error condition.
+func (rpf *resultPageIterator) checkDirectionValid(ctx context.Context, direction Direction) error {
+	if direction == DirBack {
+		// can't fetch rows previous to the start
+		if rpf.Start() == 0 {
+			return dbsqlerrint.NewDriverError(ctx, ErrRowsFetchPriorToStart, nil)
+		}
+	} else if direction == DirForward {
+		// can't fetch past the end of the query results
+		if rpf.isFinished {
+			return io.EOF
+		}
+	} else {
+		rpf.logger.Error().Msgf(errRowsUnandledFetchDirection(direction.String()))
+		return dbsqlerrint.NewDriverError(ctx, errRowsUnandledFetchDirection(direction.String()), nil)
+	}
+	return nil
+}
+
+func directionToSparkDirection(d Direction) cli_service.TFetchOrientation {
+	switch d {
+	case DirBack:
+		return cli_service.TFetchOrientation_FETCH_PRIOR
+	default:
+		return cli_service.TFetchOrientation_FETCH_NEXT
+	}
+}

--- a/internal/rows/rowscanner/resultPageIterator_test.go
+++ b/internal/rows/rowscanner/resultPageIterator_test.go
@@ -1,0 +1,150 @@
+package rowscanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	"github.com/databricks/databricks-sql-go/internal/client"
+	dbsqllog "github.com/databricks/databricks-sql-go/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchResultPageination(t *testing.T) {
+	t.Parallel()
+
+	fetches := []fetch{}
+	pageSequence := []int{0, 3, 2, 0, 1, 2}
+	client := getSimpleClient(&fetches, pageSequence)
+
+	rf := &resultPageIterator{
+		Delimiter:     NewDelimiter(0, 0),
+		client:        client,
+		logger:        dbsqllog.WithContext("connId", "correlationId", ""),
+		connectionId:  "connId",
+		correlationId: "correlationId",
+	}
+
+	// next row number is zero so should fetch first result page
+	_, err := rf.Next()
+	assert.Nil(t, err)
+	assert.Len(t, fetches, 1)
+	assert.Equal(t, fetches[0].direction, cli_service.TFetchOrientation_FETCH_NEXT)
+
+	// The test client returns rows
+	_, err = rf.Next()
+	assert.Nil(t, err)
+	assert.Len(t, fetches, 5)
+	expected := []fetch{
+		{direction: cli_service.TFetchOrientation_FETCH_NEXT, resultStartRec: 0},
+		{direction: cli_service.TFetchOrientation_FETCH_NEXT, resultStartRec: 15},
+		{direction: cli_service.TFetchOrientation_FETCH_PRIOR, resultStartRec: 10},
+		{direction: cli_service.TFetchOrientation_FETCH_PRIOR, resultStartRec: 0},
+		{direction: cli_service.TFetchOrientation_FETCH_NEXT, resultStartRec: 5},
+	}
+	assert.Equal(t, expected, fetches)
+}
+
+type fetch struct {
+	direction      cli_service.TFetchOrientation
+	resultStartRec int
+}
+
+// Build a simple test client
+func getSimpleClient(fetches *[]fetch, pageSequence []int) cli_service.TCLIService {
+	// We are simulating the scenario where network errors and retry behaviour cause the fetch
+	// result request to be sent multiple times, resulting in jumping past the next/previous result
+	// page. Behaviour should be robust enough to handle this by changing the fetch orientation.
+
+	// Metadata for the different types is based on the results returned when querying a table with
+	// all the different types which was created in a test shard.
+	metadata := &cli_service.TGetResultSetMetadataResp{
+		Status: &cli_service.TStatus{
+			StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+		},
+		Schema: &cli_service.TTableSchema{
+			Columns: []*cli_service.TColumnDesc{
+				{
+					ColumnName: "bool_col",
+					TypeDesc: &cli_service.TTypeDesc{
+						Types: []*cli_service.TTypeEntry{
+							{
+								PrimitiveEntry: &cli_service.TPrimitiveTypeEntry{
+									Type: cli_service.TTypeId_BOOLEAN_TYPE,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	getMetadata := func(ctx context.Context, req *cli_service.TGetResultSetMetadataReq) (_r *cli_service.TGetResultSetMetadataResp, _err error) {
+		return metadata, nil
+	}
+
+	moreRows := true
+	noMoreRows := false
+	colVals := []*cli_service.TColumn{{BoolVal: &cli_service.TBoolColumn{Values: []bool{true, false, true, false, true}}}}
+
+	pages := []*cli_service.TFetchResultsResp{
+		{
+			Status: &cli_service.TStatus{
+				StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+			},
+			HasMoreRows: &moreRows,
+			Results: &cli_service.TRowSet{
+				StartRowOffset: 0,
+				Columns:        colVals,
+			},
+		},
+		{
+			Status: &cli_service.TStatus{
+				StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+			},
+			HasMoreRows: &moreRows,
+			Results: &cli_service.TRowSet{
+				StartRowOffset: 5,
+				Columns:        colVals,
+			},
+		},
+		{
+			Status: &cli_service.TStatus{
+				StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+			},
+			HasMoreRows: &noMoreRows,
+			Results: &cli_service.TRowSet{
+				StartRowOffset: 10,
+				Columns:        colVals,
+			},
+		},
+		{
+			Status: &cli_service.TStatus{
+				StatusCode: cli_service.TStatusCode_SUCCESS_STATUS,
+			},
+			HasMoreRows: &noMoreRows,
+			Results: &cli_service.TRowSet{
+				StartRowOffset: 15,
+				Columns:        []*cli_service.TColumn{},
+			},
+		},
+	}
+
+	pageIndex := -1
+
+	fetchResults := func(ctx context.Context, req *cli_service.TFetchResultsReq) (_r *cli_service.TFetchResultsResp, _err error) {
+		pageIndex++
+
+		p := pages[pageSequence[pageIndex]]
+		*fetches = append(*fetches, fetch{direction: req.Orientation, resultStartRec: int(p.Results.StartRowOffset)})
+		return p, nil
+	}
+
+	client := &client.TestClient{
+		FnGetResultSetMetadata: getMetadata,
+		FnFetchResults:         fetchResults,
+	}
+
+	return client
+}


### PR DESCRIPTION
Step one of exposing arrow batches directly to users. 
Moved the logic for iterating over the pages in a result set into ResultPageIterator.  
Rows now composes in ResultPageIterator. 
Introduced Delimeter type. Delimeter tracks a start/end point and provides functions for determining if a point is within the delimiter range and the direction of the point if it is outside the delimeter range. 
Updated sparkArrowBatch, arrowRowScanner, columnRows, rows to use Delimiter. 
Updated the Fetch logic for cloudURL and localBatch so that the concurrentFetcher doesn't need to hold or pass through a Config instance.