### PR TITLE
[PECO-1116] Change version of GO being used in Github Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test and Build
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databricks/databricks-sql-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/apache/arrow/go/v12 v12.0.1


### PR DESCRIPTION
We need to change the version that we have in our Github action and bump the requirements in the go registry. (May also need to do major version change)