### PR TITLE
Bug fix: The HasNext() function for Go driver arrow record iterator returning EOF for empty result set.

### DIFF
--- a/internal/rows/arrowbased/arrowRecordIterator.go
+++ b/internal/rows/arrowbased/arrowRecordIterator.go
@@ -61,6 +61,7 @@ func (ri *arrowRecordIterator) Next() (arrow.Record, error) {
 
 // Indicate whether there are any more records available
 func (ri *arrowRecordIterator) HasNext() bool {
+	ri.checkFinished()
 	return !ri.isFinished
 }
 
@@ -83,7 +84,10 @@ func (ri *arrowRecordIterator) Close() {
 }
 
 func (ri *arrowRecordIterator) checkFinished() {
-	finished := !ri.currentBatch.HasNext() && !ri.batchIterator.HasNext() && !ri.resultPageIterator.HasNext()
+	finished := ri.isFinished ||
+		((ri.currentBatch == nil || !ri.currentBatch.HasNext()) &&
+			(ri.batchIterator == nil || !ri.batchIterator.HasNext()) &&
+			(ri.resultPageIterator == nil || !ri.resultPageIterator.HasNext()))
 
 	if finished {
 		// Reached end of result set so Close

--- a/internal/rows/testdata/zeroRows/zeroRowsDirectResults.json
+++ b/internal/rows/testdata/zeroRows/zeroRowsDirectResults.json
@@ -1,0 +1,111 @@
+{
+    "status": {
+        "statusCode": "SUCCESS_STATUS"
+    },
+    "operationHandle": {
+        "operationId": {
+            "guid": "Ae6w6uAWEI+vWuB+fjGvOA==",
+            "secret": "M41SnYJyRuuEgstBlGaDnQ==",
+            "executionVersion": 0
+        },
+        "operationType": "EXECUTE_STATEMENT",
+        "hasResultSet": true
+    },
+    "directResults": {
+        "operationStatus": {
+            "status": {
+                "statusCode": "SUCCESS_STATUS"
+            },
+            "operationState": "FINISHED_STATE",
+            "operationStarted": 1705023332453,
+            "operationCompleted": 1705023332599,
+            "idempotencyType": "IDEMPOTENT",
+            "statementTimeout": 172800
+        },
+        "resultSetMetadata": {
+            "status": {
+                "statusCode": "SUCCESS_STATUS"
+            },
+            "schema": {
+                "columns": [
+                    {
+                        "columnName": "id",
+                        "typeDesc": {
+                            "types": [
+                                {
+                                    "primitiveEntry": {
+                                        "type": "INT_TYPE"
+                                    }
+                                }
+                            ]
+                        },
+                        "position": 1,
+                        "comment": ""
+                    },
+                    {
+                        "columnName": "deleted",
+                        "typeDesc": {
+                            "types": [
+                                {
+                                    "primitiveEntry": {
+                                        "type": "BOOLEAN_TYPE"
+                                    }
+                                }
+                            ]
+                        },
+                        "position": 2,
+                        "comment": ""
+                    },
+                    {
+                        "columnName": "name",
+                        "typeDesc": {
+                            "types": [
+                                {
+                                    "primitiveEntry": {
+                                        "type": "STRING_TYPE"
+                                    }
+                                }
+                            ]
+                        },
+                        "position": 3,
+                        "comment": ""
+                    }
+                ]
+            },
+            "resultFormat": "ARROW_BASED_SET",
+            "lz4Compressed": false,
+            "arrowSchema": "/////2ACAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAMAAABsAQAArAAAAAQAAACy/v//FAAAAIgAAACIAAAAAAAFAYQAAAACAAAAQAAAAAQAAABo/v//CAAAABQAAAAIAAAAInN0cmluZyIAAAAAFwAAAFNwYXJrOkRhdGFUeXBlOkpzb25UeXBlAKD+//8IAAAAEAAAAAYAAABTVFJJTkcAABYAAABTcGFyazpEYXRhVHlwZTpTcWxOYW1lAAAAAAAAXP///wQAAABuYW1lAAAAAFb///8UAAAAiAAAAIwAAAAAAAYBiAAAAAIAAABAAAAABAAAAAz///8IAAAAFAAAAAkAAAAiYm9vbGVhbiIAAAAXAAAAU3Bhcms6RGF0YVR5cGU6SnNvblR5cGUARP///wgAAAAQAAAABwAAAEJPT0xFQU4AFgAAAFNwYXJrOkRhdGFUeXBlOlNxbE5hbWUAAAAAAAAEAAQABAAAAAcAAABkZWxldGVkAAAAEgAYABQAEwASAAwAAAAIAAQAEgAAABQAAACMAAAAlAAAAAAAAgGYAAAAAgAAAEgAAAAEAAAAyP///wgAAAAUAAAACQAAACJpbnRlZ2VyIgAAABcAAABTcGFyazpEYXRhVHlwZTpKc29uVHlwZQAIAAwACAAEAAgAAAAIAAAADAAAAAMAAABJTlQAFgAAAFNwYXJrOkRhdGFUeXBlOlNxbE5hbWUAAAAAAAAIAAwACAAHAAgAAAAAAAABIAAAAAIAAABpZAAAAAAAAA==",
+            "cacheLookupResult": "LOCAL_CACHE_HIT",
+            "uncompressedBytes": 0,
+            "compressedBytes": 0,
+            "isStagingOperation": false,
+            "reasonForNoCloudFetch": "CLOUD_FETCH_SUPPORT",
+            "cacheLookupLatency": 4,
+            "remoteResultCacheEnabled": true,
+            "isServerless": true,
+            "truncatedByThriftLimit": false
+        },
+        "resultSet": {
+            "status": {
+                "statusCode": "SUCCESS_STATUS"
+            },
+            "hasMoreRows": false,
+            "results": {
+                "startRowOffset": 0,
+                "rows": []
+            }
+        },
+        "closeOperation": {
+            "status": {
+                "statusCode": "SUCCESS_STATUS"
+            }
+        }
+    },
+    "executionRejected": false,
+    "maxClusterCapacity": 10,
+    "queryCost": 0.5,
+    "currentClusterLoad": 1,
+    "idempotencyType": "IDEMPOTENT",
+    "remoteResultCacheEnabled": true,
+    "isServerless": true
+}

--- a/internal/rows/testdata/zeroRows/zeroRowsFetchResult.json
+++ b/internal/rows/testdata/zeroRows/zeroRowsFetchResult.json
@@ -1,0 +1,73 @@
+{
+ "status": {
+  "statusCode": "SUCCESS_STATUS"
+ },
+ "hasMoreRows": false,
+ "results": {
+  "startRowOffset": 0,
+  "rows": []
+ },
+ "resultSetMetadata": {
+  "status": {
+   "statusCode": "SUCCESS_STATUS"
+  },
+  "schema": {
+   "columns": [
+    {
+     "columnName": "id",
+     "typeDesc": {
+      "types": [
+       {
+        "primitiveEntry": {
+         "type": "INT_TYPE"
+        }
+       }
+      ]
+     },
+     "position": 1,
+     "comment": ""
+    },
+    {
+     "columnName": "deleted",
+     "typeDesc": {
+      "types": [
+       {
+        "primitiveEntry": {
+         "type": "BOOLEAN_TYPE"
+        }
+       }
+      ]
+     },
+     "position": 2,
+     "comment": ""
+    },
+    {
+     "columnName": "name",
+     "typeDesc": {
+      "types": [
+       {
+        "primitiveEntry": {
+         "type": "STRING_TYPE"
+        }
+       }
+      ]
+     },
+     "position": 3,
+     "comment": ""
+    }
+   ]
+  },
+  "resultFormat": "ARROW_BASED_SET",
+  "lz4Compressed": false,
+  "arrowSchema": "/////2ACAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAMAAABsAQAArAAAAAQAAACy/v//FAAAAIgAAACIAAAAAAAFAYQAAAACAAAAQAAAAAQAAABo/v//CAAAABQAAAAIAAAAInN0cmluZyIAAAAAFwAAAFNwYXJrOkRhdGFUeXBlOkpzb25UeXBlAKD+//8IAAAAEAAAAAYAAABTVFJJTkcAABYAAABTcGFyazpEYXRhVHlwZTpTcWxOYW1lAAAAAAAAXP///wQAAABuYW1lAAAAAFb///8UAAAAiAAAAIwAAAAAAAYBiAAAAAIAAABAAAAABAAAAAz///8IAAAAFAAAAAkAAAAiYm9vbGVhbiIAAAAXAAAAU3Bhcms6RGF0YVR5cGU6SnNvblR5cGUARP///wgAAAAQAAAABwAAAEJPT0xFQU4AFgAAAFNwYXJrOkRhdGFUeXBlOlNxbE5hbWUAAAAAAAAEAAQABAAAAAcAAABkZWxldGVkAAAAEgAYABQAEwASAAwAAAAIAAQAEgAAABQAAACMAAAAlAAAAAAAAgGYAAAAAgAAAEgAAAAEAAAAyP///wgAAAAUAAAACQAAACJpbnRlZ2VyIgAAABcAAABTcGFyazpEYXRhVHlwZTpKc29uVHlwZQAIAAwACAAEAAgAAAAIAAAADAAAAAMAAABJTlQAFgAAAFNwYXJrOkRhdGFUeXBlOlNxbE5hbWUAAAAAAAAIAAwACAAHAAgAAAAAAAABIAAAAAIAAABpZAAAAAAAAA==",
+  "cacheLookupResult": "LOCAL_CACHE_HIT",
+  "uncompressedBytes": 0,
+  "compressedBytes": 0,
+  "isStagingOperation": false,
+  "reasonForNoCloudFetch": "CLOUD_FETCH_SUPPORT",
+  "cacheLookupLatency": 2,
+  "remoteResultCacheEnabled": true,
+  "isServerless": true,
+  "truncatedByThriftLimit": false
+ }
+}


### PR DESCRIPTION
Bug fix: The HasNext() function for Go driver arrow record iterator returning EOF for empty result set.

Essentially, the HasNext() logic was assuming there were records in the result set in the case that the original return from executing the statement didn't specify, or if there were no direct results.

Updated arrowRecordIterator.HasNext() to check state of underlying iterators. This handles the case of direct results that contain no records. 
Updated resultPageIterator.HasNext() to try fetching a result page if necessary to determine if there are more records.

Added tests for empty result sets with direct results enabled and disabled.
Internal ticket: [ES-975398]

[ES-975398]: https://databricks.atlassian.net/browse/ES-975398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ