### PR TITLE
Add snippet to docs for GET from staging

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -201,7 +201,11 @@ The Go driver now supports staging operations. In order to use a staging operati
 
 After doing so, you can execute staging operations using this context using the exec context.
 
+    // Upload file to staging.
 	_, err1 := db.ExecContext(ctx, `PUT 'staging/file.csv' INTO '/Volumes/main/staging_test/e2etests/file.csv' OVERWRITE`)
+
+	// Retrieve file from staging.
+	_, err2 := db.ExecContext(ctx, `GET '/Volumes/main/staging_test/e2etests/file.csv' TO 'staging/file.csv'`)
 
 # Errors
 

--- a/doc.go
+++ b/doc.go
@@ -201,7 +201,7 @@ The Go driver now supports staging operations. In order to use a staging operati
 
 After doing so, you can execute staging operations using this context using the exec context.
 
-    // Upload file to staging.
+        // Upload file to staging.
 	_, err1 := db.ExecContext(ctx, `PUT 'staging/file.csv' INTO '/Volumes/main/staging_test/e2etests/file.csv' OVERWRITE`)
 
 	// Retrieve file from staging.


### PR DESCRIPTION
We recently started using the `GET` staging operation after using `PUT` in production for some time. I thought it might be useful to have a snippet with the expected syntax in the documentation. (There is also `REMOVE` but I only see tests for `GET` and `PUT`.)

Not sure yet why I'm triggering linter errors 🤔