### PR TITLE
fix: Properly format `time.Time` values

### DIFF
--- a/parameters.go
+++ b/parameters.go
@@ -131,7 +131,7 @@ func inferTypes(params []Parameter) {
 				param.Value = strconv.FormatFloat(float64(value), 'f', -1, 32)
 				param.Type = SqlFloat
 			case time.Time:
-				param.Value = value.String()
+				param.Value = value.Format(time.RFC3339Nano)
 				param.Type = SqlTimestamp
 			default:
 				s := fmt.Sprintf("%s", param.Value)


### PR DESCRIPTION
Closes #206 