### PR TITLE
Add connection option WithSkipTLSHostVerify for privatelink host

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -2,6 +2,7 @@ package dbsql
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql/driver"
 	"fmt"
 	"net/http"
@@ -230,6 +231,20 @@ func WithSessionParams(params map[string]string) connOption {
 			}
 		}
 		c.SessionParams = params
+	}
+}
+
+// WithSkipTLSHostVerify disables the verification of the hostname in the TLS certificate.
+// WARNING:
+// When this option is used, TLS is susceptible to machine-in-the-middle attacks.
+// Please only use this option when the hostname is an internal private link hostname
+func WithSkipTLSHostVerify() connOption {
+	return func(c *config.Config) {
+		if c.TLSConfig == nil {
+			c.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} // #nosec G402
+		} else {
+			c.TLSConfig.InsecureSkipVerify = true // #nosec G402
+		}
 	}
 }
 


### PR DESCRIPTION
## Background
The driver cannot connect to the workspace whose hostname is an internal private link hostname, this is because its domain is not added into Databricks workspace certificate.  See https://github.com/databricks/databricks-sql-go/issues/223

## Description
This change adds connection option `WithSkipTLSHostVerify` which can disable verifying the hostname in the server certificate. In this mode, TLS is susceptible to machine-in-the-middle attacks. Please only use this option when the hostname is an internal private link hostname. 

Here is the usage
```go
connector, err := dbsql.NewConnector(
   dbsql.WithServerHostname("<hostname>"),
   dbsql.WithHTTPPath("<http_path>"),
   dbsql.WithAccessToken("<token>"),
   dbsql.WithSkipTLSHostVerify(),
)
```