### PR TITLE
Set spark param ordinals with NamedValue ordinals

### DIFF
--- a/parameter_test.go
+++ b/parameter_test.go
@@ -45,3 +45,20 @@ func TestParameters_Names(t *testing.T) {
 		assert.Equal(t, string("DECIMAL(2,1)"), *parameters[1].Type)
 	})
 }
+func TestParameter_Ordinals(t *testing.T) {
+	t.Run("Should infer types correctly", func(t *testing.T) {
+		values := [7]driver.NamedValue{
+			{Ordinal: 0},
+			{Ordinal: 1},
+			{Ordinal: 2},
+			{Ordinal: 3},
+			{Ordinal: 4},
+		}
+		parameters := convertNamedValuesToSparkParams(values[:])
+		assert.Equal(t, int32(0), *parameters[0].Ordinal)
+		assert.Equal(t, int32(1), *parameters[1].Ordinal)
+		assert.Equal(t, int32(2), *parameters[2].Ordinal)
+		assert.Equal(t, int32(3), *parameters[3].Ordinal)
+		assert.Equal(t, int32(4), *parameters[4].Ordinal)
+	})
+}

--- a/parameters.go
+++ b/parameters.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Parameter struct {
-	Name  string
-	Type  SqlType
-	Value any
+	Ordinal int32
+	Name    string
+	Type    SqlType
+	Value   any
 }
 
 type SqlType int
@@ -85,6 +86,7 @@ func valuesToParameters(namedValues []driver.NamedValue) []Parameter {
 			newParam.Name = namedValue.Name
 			newParam.Value = namedValue.Value
 		}
+		newParam.Ordinal = int32(namedValue.Ordinal)
 		params = append(params, newParam)
 	}
 	return params
@@ -183,7 +185,9 @@ func convertNamedValuesToSparkParams(values []driver.NamedValue) []*cli_service.
 		} else {
 			sparkParamType = sqlParam.Type.String()
 		}
-		sparkParam := cli_service.TSparkParameter{Name: &sqlParam.Name, Type: &sparkParamType, Value: sparkValue}
+		sparkParam := cli_service.TSparkParameter{
+			Ordinal: &sqlParam.Ordinal, Name: &sqlParam.Name, Type: &sparkParamType, Value: sparkValue,
+		}
 		sparkParams = append(sparkParams, &sparkParam)
 	}
 	return sparkParams


### PR DESCRIPTION
Querying with unnamed arguments raises this error:
```
ERR databricks: failed to run query error="[INVALID_PARAMETER_MARKER_VALUE.DUPLICATE_NAME] An invalid parameter mapping was provided: multiple parameter mappings were given with the name ''. SQLSTATE: 22023"
```

Unnamed arguments still have ordinal values, so this PR sets the `driver.NamedValue` ordinal value to the spark parameter.