### PR TITLE
[BL-8235] Fix a connection leak in PingContext

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -78,11 +78,12 @@ func (c *conn) Ping(ctx context.Context) error {
 
 	ctx1, cancel := context.WithTimeout(ctx, c.cfg.PingTimeout)
 	defer cancel()
-	_, err := c.QueryContext(ctx1, "select 1", nil)
+	rows, err := c.QueryContext(ctx1, "select 1", nil)
 	if err != nil {
 		log.Err(err).Msg("databricks: failed to ping")
 		return dbsqlerrint.NewBadConnectionError(err)
 	}
+	defer rows.Close()
 
 	log.Debug().Msg("databricks: ping successful")
 	return nil

--- a/connection_test.go
+++ b/connection_test.go
@@ -1370,9 +1370,14 @@ func TestConn_Ping(t *testing.T) {
 			return getOperationStatusResp, nil
 		}
 
+		var closeCount int
 		testClient := &client.TestClient{
 			FnExecuteStatement:   executeStatement,
 			FnGetOperationStatus: getOperationStatus,
+			FnCloseOperation: func(ctx context.Context, req *cli_service.TCloseOperationReq) (_r *cli_service.TCloseOperationResp, _err error) {
+				closeCount++
+				return nil, nil
+			},
 		}
 
 		testConn := &conn{
@@ -1384,6 +1389,7 @@ func TestConn_Ping(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, executeStatementCount)
+		assert.Equal(t, 1, closeCount)
 	})
 }
 

--- a/connector.go
+++ b/connector.go
@@ -236,7 +236,7 @@ func WithSessionParams(params map[string]string) ConnOption {
 // WARNING:
 // When this option is used, TLS is susceptible to machine-in-the-middle attacks.
 // Please only use this option when the hostname is an internal private link hostname
-func WithSkipTLSHostVerify() connOption {
+func WithSkipTLSHostVerify() ConnOption {
 	return func(c *config.Config) {
 		if c.TLSConfig == nil {
 			c.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} // #nosec G402


### PR DESCRIPTION
Connection.Ping does not close the result set from query, which leads to open result set