### PR TITLE
pass ctx properly in internal client.ExecuteStatement

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -167,8 +167,7 @@ func (tsc *ThriftServiceClient) ExecuteStatement(ctx context.Context, req *cli_s
 	log, ctx = LoggerAndContext(ctx, req)
 	msg, start := log.Track("ExecuteStatement")
 
-	// We use context.Background to fix a problem where on context done the query would not be cancelled.
-	resp, err := tsc.TCLIServiceClient.ExecuteStatement(context.Background(), req)
+	resp, err := tsc.TCLIServiceClient.ExecuteStatement(ctx, req)
 	log, ctx = LoggerAndContext(ctx, resp)
 	logDisplayMessage(resp, log)
 	logExecStatementState(resp, log)


### PR DESCRIPTION
Fixes https://github.com/databricks/databricks-sql-go/issues/242
Fixes https://github.com/databricks/databricks-sql-go/issues/231

This needs to actually pass ctx so custom authenticators can make use of the context.