### PR TITLE
[PECO-2050] Add custom auth headers into cloud fetch request

### DIFF
--- a/internal/rows/arrowbased/batchloader.go
+++ b/internal/rows/arrowbased/batchloader.go
@@ -277,6 +277,12 @@ func fetchBatchBytes(
 		return nil, err
 	}
 
+	if link.HttpHeaders != nil {
+		for key, value := range link.HttpHeaders {
+			req.Header.Set(key, value)
+		}
+	}
+
 	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
When file encryption is enabled with customer provided keys (SSE-CPK), we must pass the keys in HTTP headers in the fetch request. These headers are provided in the property `httpHeaders` in the `TSparkArrowResultLink`
