### PR TITLE
Propagate error in TFetchResults

### DIFF
--- a/internal/rows/rows.go
+++ b/internal/rows/rows.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"io"
 	"math"
 	"reflect"
 	"time"
@@ -454,10 +453,6 @@ func (r *rows) fetchResultPage() error {
 	if r.RowScanner != nil {
 		r.RowScanner.Close()
 		r.RowScanner = nil
-	}
-
-	if !r.ResultPageIterator.HasNext() {
-		return io.EOF
 	}
 
 	fetchResult, err1 := r.ResultPageIterator.Next()


### PR DESCRIPTION
Currently, an error thrown in TFetchResults within getNextPage in resultPageIterator will be swallowed and an EOF err will be returned instead. This PR solves #254 