### PR TITLE
enable cloud fetch by default

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -89,7 +89,7 @@ func TestNewConnector(t *testing.T) {
 			WithHTTPPath(httpPath),
 		)
 		expectedCloudFetchConfig := config.CloudFetchConfig{
-			UseCloudFetch:      false,
+			UseCloudFetch:      true,
 			MaxDownloadThreads: 10,
 			MaxFilesInMemory:   10,
 			MinTimeToExpiry:    0 * time.Second,
@@ -130,7 +130,7 @@ func TestNewConnector(t *testing.T) {
 			WithRetries(-1, 0, 0),
 		)
 		expectedCloudFetchConfig := config.CloudFetchConfig{
-			UseCloudFetch:      false,
+			UseCloudFetch:      true,
 			MaxDownloadThreads: 10,
 			MaxFilesInMemory:   10,
 			MinTimeToExpiry:    0 * time.Second,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -471,7 +471,7 @@ type CloudFetchConfig struct {
 }
 
 func (cfg CloudFetchConfig) WithDefaults() CloudFetchConfig {
-	cfg.UseCloudFetch = false
+	cfg.UseCloudFetch = true
 
 	if cfg.MaxDownloadThreads <= 0 {
 		cfg.MaxDownloadThreads = 10


### PR DESCRIPTION
## Description
Enable cloud fetch (EXTERNAL_LINKS) by default. 

## Testing
Benchmark tests

### Benchmarking results
Following table demonstrates the improvement in execution times for large queries.
| test_case | percent_reduction |
|-----------|------------------|
| large_results_2050mb | 56.58973580321896 |
| large_results_1025mb | 51.78689883913764 |
| large_results_0500mb | 47.729468599033815 |
| large_results_0100mb | 40.57221647707687 |
| large_results_0250mb | 38.71932974266906 |
| large_results_0050mb | 19.751809720785936 |
| large_results_0025mb | -7.421625079974409 |
| large_results_0010mb | -7.752808988764046 |
| large_results_0005mb | -36.91376701966717 |

We get **~57%** deduction in large queries execution time. 
For result size > 4.1GB, we cannot even fetch without cloud fetch with default spark configs.
Ref error: `ERR Total size of serialized results of 32 tasks (4.1 GiB) is bigger than spark.driver.maxResultSize 4.0 GiB.`