### PR TITLE
[PECOBLR-314] handle thrift protocol version

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -18,9 +18,9 @@ import (
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	dbsqlerrint "github.com/databricks/databricks-sql-go/internal/errors"
-	"github.com/databricks/databricks-sql-go/internal/thrift_protocol"
 	"github.com/databricks/databricks-sql-go/internal/rows"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
+	"github.com/databricks/databricks-sql-go/internal/thrift_protocol"
 	"github.com/databricks/databricks-sql-go/logger"
 	"github.com/pkg/errors"
 )

--- a/connection.go
+++ b/connection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
 	dbsqlerrint "github.com/databricks/databricks-sql-go/internal/errors"
+	"github.com/databricks/databricks-sql-go/internal/thrift_protocol"
 	"github.com/databricks/databricks-sql-go/internal/rows"
 	"github.com/databricks/databricks-sql-go/internal/sentinel"
 	"github.com/databricks/databricks-sql-go/logger"
@@ -285,14 +286,30 @@ func (c *conn) executeStatement(ctx context.Context, query string, args []driver
 		Statement:     query,
 		RunAsync:      true,
 		QueryTimeout:  int64(c.cfg.QueryTimeout / time.Second),
-		GetDirectResults: &cli_service.TSparkGetDirectResults{
-			MaxRows: int64(c.cfg.MaxRows),
-		},
-		CanDecompressLZ4Result_: &c.cfg.UseLz4Compression,
-		Parameters:              parameters,
 	}
 
-	if c.cfg.UseArrowBatches {
+	// Check protocol version for feature support
+	serverProtocolVersion := c.session.ServerProtocolVersion
+
+	// Add direct results if supported
+	if thrift_protocol.SupportsDirectResults(serverProtocolVersion) {
+		req.GetDirectResults = &cli_service.TSparkGetDirectResults{
+			MaxRows: int64(c.cfg.MaxRows),
+		}
+	}
+
+	// Add LZ4 compression if supported and enabled
+	if thrift_protocol.SupportsLz4Compression(serverProtocolVersion) && c.cfg.UseLz4Compression {
+		req.CanDecompressLZ4Result_ = &c.cfg.UseLz4Compression
+	}
+
+	// Add cloud fetch if supported and enabled
+	if thrift_protocol.SupportsCloudFetch(serverProtocolVersion) && c.cfg.UseCloudFetch {
+		req.CanDownloadResult_ = &c.cfg.UseCloudFetch
+	}
+
+	// Add Arrow support if supported and enabled
+	if thrift_protocol.SupportsArrow(serverProtocolVersion) && c.cfg.UseArrowBatches {
 		req.CanReadArrowResult_ = &c.cfg.UseArrowBatches
 		req.UseArrowNativeTypes = &cli_service.TSparkArrowTypes{
 			DecimalAsArrow:       &c.cfg.UseArrowNativeDecimal,
@@ -302,8 +319,9 @@ func (c *conn) executeStatement(ctx context.Context, query string, args []driver
 		}
 	}
 
-	if c.cfg.UseCloudFetch {
-		req.CanDownloadResult_ = &c.cfg.UseCloudFetch
+	// Add parameters if supported and provided
+	if thrift_protocol.SupportsParameterizedQueries(serverProtocolVersion) && len(parameters) > 0 {
+		req.Parameters = parameters
 	}
 
 	resp, err := c.client.ExecuteStatement(ctx, &req)

--- a/connector.go
+++ b/connector.go
@@ -63,7 +63,7 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 	log := logger.WithContext(conn.id, driverctx.CorrelationIdFromContext(ctx), "")
 
-	log.Info().Msgf("connect: host=%s port=%d httpPath=%s", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath)
+	log.Info().Msgf("connect: host=%s port=%d httpPath=%s serverProtocolVersion=0x%X", c.cfg.Host, c.cfg.Port, c.cfg.HTTPPath, session.ServerProtocolVersion)
 
 	for k, v := range c.cfg.SessionParams {
 		setStmt := fmt.Sprintf("SET `%s` = `%s`;", k, v)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -94,6 +94,11 @@ func (tsc *ThriftServiceClient) OpenSession(ctx context.Context, req *cli_servic
 		return resp, err
 	}
 
+	// Log the server protocol version
+	if resp != nil {
+		log.Debug().Msgf("Server protocol version: 0x%X", resp.ServerProtocolVersion)
+	}
+
 	recordResult(ctx, resp)
 
 	return resp, CheckStatus(resp)

--- a/internal/client/testclient.go
+++ b/internal/client/testclient.go
@@ -10,6 +10,9 @@ import (
 var ErrNotImplemented = errors.New("databricks: not implemented")
 
 type TestClient struct {
+	// Default server protocol version to use in tests
+	ServerProtocolVersion cli_service.TProtocolVersion
+
 	FnOpenSession           func(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error)
 	FnCloseSession          func(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error)
 	FnGetInfo               func(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error)
@@ -39,7 +42,20 @@ func (c *TestClient) OpenSession(ctx context.Context, req *cli_service.TOpenSess
 	if c.FnOpenSession != nil {
 		return c.FnOpenSession(ctx, req)
 	}
-	return nil, ErrNotImplemented
+
+	// Default implementation for test client
+	resp := &cli_service.TOpenSessionResp{
+		Status:                &cli_service.TStatus{StatusCode: cli_service.TStatusCode_SUCCESS_STATUS},
+		ServerProtocolVersion: c.ServerProtocolVersion,
+		SessionHandle: &cli_service.TSessionHandle{
+			SessionId: &cli_service.THandleIdentifier{
+				GUID:   []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				Secret: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			},
+		},
+	}
+
+	return resp, nil
 }
 func (c *TestClient) CloseSession(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error) {
 	if c.FnCloseSession != nil {

--- a/internal/client/testclient.go
+++ b/internal/client/testclient.go
@@ -10,9 +10,6 @@ import (
 var ErrNotImplemented = errors.New("databricks: not implemented")
 
 type TestClient struct {
-	// Default server protocol version to use in tests
-	ServerProtocolVersion cli_service.TProtocolVersion
-
 	FnOpenSession           func(ctx context.Context, req *cli_service.TOpenSessionReq) (_r *cli_service.TOpenSessionResp, _err error)
 	FnCloseSession          func(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error)
 	FnGetInfo               func(ctx context.Context, req *cli_service.TGetInfoReq) (_r *cli_service.TGetInfoResp, _err error)
@@ -42,20 +39,7 @@ func (c *TestClient) OpenSession(ctx context.Context, req *cli_service.TOpenSess
 	if c.FnOpenSession != nil {
 		return c.FnOpenSession(ctx, req)
 	}
-
-	// Default implementation for test client
-	resp := &cli_service.TOpenSessionResp{
-		Status:                &cli_service.TStatus{StatusCode: cli_service.TStatusCode_SUCCESS_STATUS},
-		ServerProtocolVersion: c.ServerProtocolVersion,
-		SessionHandle: &cli_service.TSessionHandle{
-			SessionId: &cli_service.THandleIdentifier{
-				GUID:   []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-				Secret: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-			},
-		},
-	}
-
-	return resp, nil
+	return nil, ErrNotImplemented
 }
 func (c *TestClient) CloseSession(ctx context.Context, req *cli_service.TCloseSessionReq) (_r *cli_service.TCloseSessionResp, _err error) {
 	if c.FnCloseSession != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -648,7 +648,7 @@ func TestConfig_DeepCopy(t *testing.T) {
 			DriverVersion:             "0.9.0",
 			ThriftProtocol:            "binary",
 			ThriftTransport:           "http",
-			ThriftProtocolVersion:     cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6,
+			ThriftProtocolVersion:     cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V8,
 			ThriftDebugClientProtocol: false,
 		}
 

--- a/internal/thrift_protocol/protocol_feature_util.go
+++ b/internal/thrift_protocol/protocol_feature_util.go
@@ -1,0 +1,48 @@
+package thrift_protocol
+
+import "github.com/databricks/databricks-sql-go/internal/cli_service"
+
+
+
+// Feature checks
+// SupportsDirectResults checks if the server protocol version supports direct results
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V1 and above
+func SupportsDirectResults(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V1
+}
+
+// SupportsLz4Compression checks if the server protocol version supports LZ4 compression
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V6 and above
+func SupportsLz4Compression(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6
+}
+
+// SupportsCloudFetch checks if the server protocol version supports cloud fetch
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V3 and above
+func SupportsCloudFetch(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V3
+}
+
+// SupportsArrow checks if the server protocol version supports Arrow format
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V5 and above
+func SupportsArrow(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V5
+}
+
+// SupportsCompressedArrow checks if the server protocol version supports compressed Arrow format
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V6 and above
+func SupportsCompressedArrow(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6
+}
+
+// SupportsParameterizedQueries checks if the server protocol version supports parameterized queries
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V8 and above
+func SupportsParameterizedQueries(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V8
+}
+
+// SupportsMultipleCatalogs checks if the server protocol version supports multiple catalogs
+// Supported in SPARK_CLI_SERVICE_PROTOCOL_V4 and above
+func SupportsMultipleCatalogs(version cli_service.TProtocolVersion) bool {
+	return version >= cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V4
+}

--- a/internal/thrift_protocol/protocol_feature_util.go
+++ b/internal/thrift_protocol/protocol_feature_util.go
@@ -2,8 +2,6 @@ package thrift_protocol
 
 import "github.com/databricks/databricks-sql-go/internal/cli_service"
 
-
-
 // Feature checks
 // SupportsDirectResults checks if the server protocol version supports direct results
 // Supported in SPARK_CLI_SERVICE_PROTOCOL_V1 and above

--- a/internal/thrift_protocol/protocol_feature_util_test.go
+++ b/internal/thrift_protocol/protocol_feature_util_test.go
@@ -1,0 +1,136 @@
+package thrift_protocol
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sql-go/internal/cli_service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocolFeatureSupport(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		version                    cli_service.TProtocolVersion
+		expectDirectResults        bool
+		expectLz4Compression       bool
+		expectCloudFetch           bool
+		expectArrow                bool
+		expectCompressedArrow      bool
+		expectParameterizedQueries bool
+		expectMultipleCatalogs     bool
+	}{
+		{
+			name:                       "Protocol V1",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V1,
+			expectDirectResults:        true,
+			expectLz4Compression:       false,
+			expectCloudFetch:           false,
+			expectArrow:                false,
+			expectCompressedArrow:      false,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     false,
+		},
+		{
+			name:                       "Protocol V2",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V2,
+			expectDirectResults:        true,
+			expectLz4Compression:       false,
+			expectCloudFetch:           false,
+			expectArrow:                false,
+			expectCompressedArrow:      false,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     false,
+		},
+		{
+			name:                       "Protocol V3",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V3,
+			expectDirectResults:        true,
+			expectLz4Compression:       false,
+			expectCloudFetch:           true,
+			expectArrow:                false,
+			expectCompressedArrow:      false,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     false,
+		},
+		{
+			name:                       "Protocol V4",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V4,
+			expectDirectResults:        true,
+			expectLz4Compression:       false,
+			expectCloudFetch:           true,
+			expectArrow:                false,
+			expectCompressedArrow:      false,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     true,
+		},
+		{
+			name:                       "Protocol V5",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V5,
+			expectDirectResults:        true,
+			expectLz4Compression:       false,
+			expectCloudFetch:           true,
+			expectArrow:                true,
+			expectCompressedArrow:      false,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     true,
+		},
+		{
+			name:                       "Protocol V6",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V6,
+			expectDirectResults:        true,
+			expectLz4Compression:       true,
+			expectCloudFetch:           true,
+			expectArrow:                true,
+			expectCompressedArrow:      true,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     true,
+		},
+		{
+			name:                       "Protocol V7",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V7,
+			expectDirectResults:        true,
+			expectLz4Compression:       true,
+			expectCloudFetch:           true,
+			expectArrow:                true,
+			expectCompressedArrow:      true,
+			expectParameterizedQueries: false,
+			expectMultipleCatalogs:     true,
+		},
+		{
+			name:                       "Protocol V8",
+			version:                    cli_service.TProtocolVersion_SPARK_CLI_SERVICE_PROTOCOL_V8,
+			expectDirectResults:        true,
+			expectLz4Compression:       true,
+			expectCloudFetch:           true,
+			expectArrow:                true,
+			expectCompressedArrow:      true,
+			expectParameterizedQueries: true,
+			expectMultipleCatalogs:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectDirectResults, SupportsDirectResults(tc.version),
+				"DirectResults support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectLz4Compression, SupportsLz4Compression(tc.version),
+				"LZ4Compression support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectCloudFetch, SupportsCloudFetch(tc.version),
+				"CloudFetch support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectArrow, SupportsArrow(tc.version),
+				"Arrow support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectCompressedArrow, SupportsCompressedArrow(tc.version),
+				"CompressedArrow support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectParameterizedQueries, SupportsParameterizedQueries(tc.version),
+				"ParameterizedQueries support check failed for %s", tc.name)
+
+			assert.Equal(t, tc.expectMultipleCatalogs, SupportsMultipleCatalogs(tc.version),
+				"MultipleCatalogs support check failed for %s", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces changes to handle thrift protocol version returned in TOpenSessionResp for supporting different features like cloud fetch, compression, parameterized queries.

### Protocol Version Support:
* [`connection.go`](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L288-R312): Added checks for server protocol version to conditionally support features such as direct results, LZ4 compression, cloud fetch, Arrow format, and parameterized queries. [[1]](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L288-R312) [[2]](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L305-R324)
* [`internal/thrift_protocol/protocol_feature_util.go`](diffhunk://#diff-6d5ab0961a6f4e5eee4a29f813d12b51e54f5f45ccaed7360eb6a685e193a1a4R1-R48): Introduced utility functions to check for feature support based on the server protocol version.

## Testing
* [`internal/client/testclient.go`](diffhunk://#diff-23ebebc8a40cb5a963a06a6f99116d364a623dcf4c17979f4d8109b62c024959R13-R15): Updated the test client to include a default server protocol version and a default implementation for opening a session. [[1]](diffhunk://#diff-23ebebc8a40cb5a963a06a6f99116d364a623dcf4c17979f4d8109b62c024959R13-R15) [[2]](diffhunk://#diff-23ebebc8a40cb5a963a06a6f99116d364a623dcf4c17979f4d8109b62c024959L42-R58)
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L651-R651): Changed the default protocol version in the test configuration.