### PR TITLE
prepare release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## v1.7.0 (2025-04-09)
+
+- Enable cloud fetch mode by default (databricks/databricks-sql-go#260)
+- Handle thrift protocol version for conditional feature support (direct results, LZ4 compression, Arrow support, parameterized queries) (databricks/databricks-sql-go#261)
+
 ## v1.6.2 (2025-03-18)
 
 - Support positional query parameters (databricks/databricks-sql-go#247)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ You can set query timeout value by appending a `timeout` query parameter (in sec
 ```
 token:[your token]@[Workspace hostname]:[Port number][Endpoint HTTP Path]?timeout=1000&maxRows=1000
 ```
-You can turn on Cloud Fetch to increase the performance of extracting large query results by fetching data in parallel via cloud storage (more info [here](https://www.databricks.com/blog/2021/08/11/how-we-achieved-high-bandwidth-connectivity-with-bi-tools.html)). To turn on Cloud Fetch, append `useCloudFetch=true`. You can also set the number of concurrently fetching goroutines by setting the `maxDownloadThreads` query parameter (default is 10):
+You can turn on Cloud Fetch (now enabled by default) to increase the performance of extracting large query results by fetching data in parallel via cloud storage (more info [here](https://www.databricks.com/blog/2021/08/11/how-we-achieved-high-bandwidth-connectivity-with-bi-tools.html)). You can also set the number of concurrently fetching goroutines by setting the `maxDownloadThreads` query parameter (default is 10):
+
 ```
 token:[your token]@[Workspace hostname]:[Port number][Endpoint HTTP Path]?useCloudFetch=true&maxDownloadThreads=3
+```
+To disable Cloud Fetch (e.g., when handling smaller datasets or to avoid additional overhead), append `useCloudFetch=false`:
+```
+token:[your token]@[Workspace hostname]:[Port number][Endpoint HTTP Path]?useCloudFetch=false
 ```
 
 ### Connecting with a new Connector

--- a/doc.go
+++ b/doc.go
@@ -37,7 +37,7 @@ Supported optional connection parameters can be specified in param=value and inc
   - maxRows: Sets up the max rows fetched per request. Default is 100000
   - timeout: Adds timeout (in seconds) for the server query execution. Default is no timeout
   - userAgentEntry: Used to identify partners. Set as a string with format <isv-name+product-name>
-  - useCloudFetch: Used to enable cloud fetch for the query execution. Default is false
+  - useCloudFetch: Used to enable cloud fetch for the query execution. Default is true
   - maxDownloadThreads: Sets up the max number of concurrent workers for cloud fetch. Default is 10
   - authType: Specifies the desired authentication type. Valid values are: Pat, OauthM2M, OauthU2M
   - accessToken: Personal access token. Required if authType set to Pat
@@ -85,7 +85,7 @@ Supported functional options include:
   - WithSessionParams(<params_map> map[string]string): Sets up session parameters including "timezone" and "ansi_mode". Optional
   - WithTimeout(<timeout> Duration). Adds timeout (in time.Duration) for the server query execution. Default is no timeout. Optional
   - WithUserAgentEntry(<isv-name+product-name> string). Used to identify partners. Optional
-  - WithCloudFetch (bool). Used to enable cloud fetch for the query execution. Default is false. Optional
+  - WithCloudFetch (bool). Used to enable cloud fetch for the query execution. Default is true. Optional
   - WithMaxDownloadThreads (<num_threads> int). Sets up the max number of concurrent workers for cloud fetch. Default is 10. Optional
   - WithAuthenticator (<authenticator> auth.Authenticator). Sets up authentication. Required if neither access token or client credentials are provided.
   - WithClientCredentials(<clientID> string, <clientSecret> string). Sets up Oauth M2M authentication.

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.6.2" // update version before each release
+var DriverVersion = "1.7.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
Prepare for the next release of go driver (1.7.0) which adds the following changes:

- Enable cloud fetch mode by default (databricks/databricks-sql-go#260)
- Handle thrift protocol version for conditional feature support (direct results, LZ4 compression, Arrow support, parameterized queries) (databricks/databricks-sql-go#261)