### PR TITLE
Add schema to ArrowBatchIterator

### DIFF
--- a/rows/rows.go
+++ b/rows/rows.go
@@ -20,4 +20,7 @@ type ArrowBatchIterator interface {
 
 	// Release any resources in use by the iterator.
 	Close()
+
+	// Return the schema of the records.
+	Schema() (*arrow.Schema, error)
 }


### PR DESCRIPTION
Allow ability to get the arrow schema when fetching Arrow Batches.

Currently, the GetArrowBatches(ctx) method in the DBSQL driver does not expose schema information, this PR adds support to get Schema directly like the Arrow Flight interface.