### PR TITLE
[PECOBLR-676] passing session params in open session request instead of SET commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 
 # Binaries for programs and plugins
 *.exe

--- a/examples/query_tags/main.go
+++ b/examples/query_tags/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	dbsql "github.com/databricks/databricks-sql-go"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+
+	_ = godotenv.Load()
+
+	port, err := strconv.Atoi(os.Getenv("DATABRICKS_PORT"))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(os.Getenv("DATABRICKS_HOST")),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(os.Getenv("DATABRICKS_HTTPPATH")),
+		dbsql.WithAccessToken(os.Getenv("DATABRICKS_ACCESSTOKEN")),
+		dbsql.WithSessionParams(map[string]string{
+			"QUERY_TAGS": "team:engineering,test:query-tags,driver:go",
+			"ansi_mode":  "false",
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ctx := context.Background()
+	var result int
+	err = db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			fmt.Println("not found")
+			return
+		} else {
+			fmt.Printf("err: %v\n", err)
+		}
+	}
+	fmt.Println(result)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,7 +129,7 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name: "with query params and session params",
-			args: args{dsn: "token:supersecret@example.cloud.databricks.com:8000/sql/1.0/endpoints/12346a5b5b0e123a?timeout=100&maxRows=1000&timezone=America/Vancouver"},
+			args: args{dsn: "token:supersecret@example.cloud.databricks.com:8000/sql/1.0/endpoints/12346a5b5b0e123a?timeout=100&maxRows=1000&timezone=America/Vancouver&QUERY_TAGS=team:testing,driver:go"},
 			wantCfg: UserConfig{
 				Protocol:         "https",
 				Host:             "example.cloud.databricks.com",
@@ -140,7 +140,7 @@ func TestParseConfig(t *testing.T) {
 				QueryTimeout:     100 * time.Second,
 				MaxRows:          1000,
 				Location:         tz,
-				SessionParams:    map[string]string{"timezone": "America/Vancouver"},
+				SessionParams:    map[string]string{"timezone": "America/Vancouver", "QUERY_TAGS": "team:testing,driver:go"},
 				RetryMax:         4,
 				RetryWaitMin:     1 * time.Second,
 				RetryWaitMax:     30 * time.Second,


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->

## Description
This PR **refactors session parameter handling** in the Go SQL Connector to align with other Databricks drivers (Java, Python). Previously, session parameters were set using `SET` statements after connection establishment, which was inefficient and inconsistent with other drivers. This new implementation also supports usage of QUERY_TAGS session parameter. Query Tags allow users to attach key-value pairs to SQL executions that appear in the `system.query.history` table.

### Changes Made:

1. **Refactored Session Parameter Flow** (`connector.go`):
   - **Before**: Session parameters were sent via `SET` statements after `OpenSession`
   - **After**: Session parameters are passed directly to `TOpenSessionReq.Configuration` during session creation
   - **Benefit**: Aligns with Java and Python drivers, and improves performance

2. **Created Example** (`examples/query_tags/main.go`):
   - Demonstrates the usage of Query Tags

4. **Enhanced Unit Tests** (`internal/config/config_test.go`):
   - Added `QUERY_TAGS` to DSN parsing test to verify parameter extraction

### Change from User Perspective:

The key difference is in **error timing**: Previously, invalid session parameters would fail during connection establishment (SET command execution), but now they fail during the first query execution. This happens because the Databricks backend uses lazy validation - it accepts session parameters during connection but validates them only when the first query is executed. This matches Python driver behavior.

### Query tags usage example:
```go
connector, err := dbsql.NewConnector(
    dbsql.WithSessionParams(map[string]string{
        "timezone":   "America/Sao_Paulo",
        "ansi_mode":  "true",
        "QUERY_TAGS": "team:engineering",
    }),
)
```

## How is this tested?

- [x] Unit tests
- [x] Manually

### Testing Details:

**Unit Tests**:
- Enhanced DSN parsing tests to verify session parameter extraction for query tags
- All existing tests pass with the new implementation

**Manual Testing**:
- Verified session parameters including query tags work correctly with real backend using the created example
