### PR TITLE
Fix context loss in polling and connection close operations

### DIFF
--- a/internal/compat/context/context.go
+++ b/internal/compat/context/context.go
@@ -1,0 +1,39 @@
+package context
+
+import (
+	"context"
+	"time"
+)
+
+// This implementation has been copied from https://github.com/golang/go/blob/master/src/context/context.go#L581
+// and adapted to work with this package.
+
+// WithoutCancel returns a derived context that points to the parent context
+// and is not canceled when parent is canceled.
+// The returned context returns no Deadline or Err, and its Done channel is nil.
+func WithoutCancel(parent context.Context) context.Context {
+	if parent == nil {
+		panic("cannot create context from nil parent")
+	}
+	return withoutCancelCtx{parent}
+}
+
+type withoutCancelCtx struct {
+	c context.Context
+}
+
+func (withoutCancelCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (withoutCancelCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (withoutCancelCtx) Err() error {
+	return nil
+}
+
+func (c withoutCancelCtx) Value(key any) any {
+	return c.c.Value(key)
+}

--- a/internal/rows/arrowbased/arrowRecordIterator_test.go
+++ b/internal/rows/arrowbased/arrowRecordIterator_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/databricks/databricks-sql-go/driverctx"
 	"github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/databricks/databricks-sql-go/internal/client"
 	"github.com/databricks/databricks-sql-go/internal/config"
@@ -32,15 +33,17 @@ func TestArrowRecordIterator(t *testing.T) {
 
 		var fetchesInfo []fetchResultsInfo
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		simpleClient := getSimpleClient(&fetchesInfo, []cli_service.TFetchResultsResp{fetchResp1, fetchResp2})
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 7311),
 			5000,
 			nil,
 			false,
 			simpleClient,
-			"connectionId",
-			"correlationId",
 			logger,
 		)
 
@@ -126,17 +129,19 @@ func TestArrowRecordIterator(t *testing.T) {
 		fetchResp3 := cli_service.TFetchResultsResp{}
 		loadTestData2(t, "multipleFetch/FetchResults3.json", &fetchResp3)
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		var fetchesInfo []fetchResultsInfo
 
 		simpleClient := getSimpleClient(&fetchesInfo, []cli_service.TFetchResultsResp{fetchResp1, fetchResp2, fetchResp3})
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 0),
 			5000,
 			nil,
 			false,
 			simpleClient,
-			"connectionId",
-			"correlationId",
 			logger,
 		)
 
@@ -199,16 +204,18 @@ func TestArrowRecordIteratorSchema(t *testing.T) {
 		fetchResp1 := cli_service.TFetchResultsResp{}
 		loadTestData2(t, "directResultsMultipleFetch/FetchResults1.json", &fetchResp1)
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		var fetchesInfo []fetchResultsInfo
 		simpleClient := getSimpleClient(&fetchesInfo, []cli_service.TFetchResultsResp{fetchResp1})
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 0),
 			5000,
 			nil,
 			false,
 			simpleClient,
-			"connectionId",
-			"correlationId",
 			logger,
 		)
 
@@ -251,16 +258,18 @@ func TestArrowRecordIteratorSchema(t *testing.T) {
 		fetchResp1 := cli_service.TFetchResultsResp{}
 		loadTestData2(t, "multipleFetch/FetchResults1.json", &fetchResp1)
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		var fetchesInfo []fetchResultsInfo
 		simpleClient := getSimpleClient(&fetchesInfo, []cli_service.TFetchResultsResp{fetchResp1})
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 0),
 			5000,
 			nil,
 			false,
 			simpleClient,
-			"connectionId",
-			"correlationId",
 			logger,
 		)
 
@@ -293,14 +302,16 @@ func TestArrowRecordIteratorSchema(t *testing.T) {
 			},
 		}
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 0),
 			5000,
 			nil,
 			false,
 			failingClient,
-			"connectionId",
-			"correlationId",
 			logger,
 		)
 

--- a/internal/rows/arrowbased/arrowRows_test.go
+++ b/internal/rows/arrowbased/arrowRows_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
+	"github.com/databricks/databricks-sql-go/driverctx"
 	dbsqlerr "github.com/databricks/databricks-sql-go/errors"
 	"github.com/databricks/databricks-sql-go/internal/cli_service"
 	"github.com/databricks/databricks-sql-go/internal/config"
@@ -1525,18 +1526,20 @@ func TestArrowRowScanner(t *testing.T) {
 		fetchResp2 := cli_service.TFetchResultsResp{}
 		loadTestData2(t, "directResultsMultipleFetch/FetchResults2.json", &fetchResp2)
 
+		ctx := driverctx.NewContextWithConnId(context.Background(), "connectionId")
+		ctx = driverctx.NewContextWithCorrelationId(ctx, "correlationId")
+
 		var fetchesInfo []fetchResultsInfo
 		client := getSimpleClient(&fetchesInfo, []cli_service.TFetchResultsResp{fetchResp1, fetchResp2})
 		logger := dbsqllog.WithContext("connectionId", "correlationId", "")
 
 		rpi := rowscanner.NewResultPageIterator(
+			ctx,
 			rowscanner.NewDelimiter(0, 7311),
 			5000,
 			nil,
 			false,
 			client,
-			"connectionId",
-			"correlationId",
 			logger)
 
 		cfg := config.WithDefaults()


### PR DESCRIPTION
This PR fixes an issue where the driver discards the `context.Context` during polling, making it impossible to use authentication mechanisms (like Azure OBO) that rely on passing credentials via the context.

Reference:
- https://github.com/databricks/databricks-sql-go/issues/288
- https://github.com/grafana/grafana/issues/112955