### PR TITLE
[PECOBLR-1156] Add foundational structures for transaction support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -26,10 +26,16 @@ import (
 )
 
 type conn struct {
-	id      string
-	cfg     *config.Config
-	client  cli_service.TCLIService
-	session *cli_service.TOpenSessionResp
+	id         string
+	cfg        *config.Config
+	client     cli_service.TCLIService
+	session    *cli_service.TOpenSessionResp
+	autoCommit bool // Cache autocommit state client-side (default: true)
+}
+
+// tx implements driver.Tx for transaction support
+type tx struct {
+	conn *conn
 }
 
 // Prepare prepares a statement with the query bound to this connection.

--- a/connector.go
+++ b/connector.go
@@ -67,10 +67,11 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 
 	conn := &conn{
-		id:      client.SprintGuid(session.SessionHandle.GetSessionId().GUID),
-		cfg:     c.cfg,
-		client:  tclient,
-		session: session,
+		id:         client.SprintGuid(session.SessionHandle.GetSessionId().GUID),
+		cfg:        c.cfg,
+		client:     tclient,
+		session:    session,
+		autoCommit: true, // Initialize autocommit cache to true (default state)
 	}
 	log := logger.WithContext(conn.id, driverctx.CorrelationIdFromContext(ctx), "")
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,6 +17,13 @@ const (
 	ErrParametersNotSupported            = "query parameters are not supported by this server"
 	ErrMixedNamedAndPositionalParameters = "named and positional parameters cannot be used simultaneously"
 
+	// Transaction errors
+	ErrTransactionBegin      = "failed to begin transaction"
+	ErrTransactionCommit     = "failed to commit transaction"
+	ErrTransactionRollback   = "failed to rollback transaction"
+	ErrTransactionNested     = "transaction already in progress"
+	ErrUnsupportedIsolation  = "unsupported transaction isolation level"
+
 	// Request error messages (connection, authentication, network error)
 	ErrCloseConnection = "failed to close connection"
 	ErrThriftClient    = "error initializing thrift client"


### PR DESCRIPTION
## Summary
Implement foundational infrastructure for Multi-Statement Transaction (MST) support in the Go driver, adding core structures and error constants needed for transaction implementation.

## Changes
- Add `autoCommit bool` field to `conn` struct for client-side state caching
- Create `tx` struct with `conn *conn` field implementing `driver.Tx` interface
- Add 5 transaction error constants:
  - `ErrTransactionBegin` - "failed to begin transaction"
  - `ErrTransactionCommit` - "failed to commit transaction"
  - `ErrTransactionRollback` - "failed to rollback transaction"
  - `ErrTransactionNested` - "transaction already in progress"
  - `ErrUnsupportedIsolation` - "unsupported transaction isolation level"
- Initialize `autoCommit = true` in connector (default state)

## Testing
- ✅ Code compiles successfully (`go build ./...`)
- ✅ Static analysis passes (`go vet ./...`)
- ✅ Pre-commit hooks passed
- Note: No functional tests in this ticket (foundational structures only)
- Full testing will be implemented in PECOBLR-1160 and PECOBLR-1161

## JIRA
Closes [PECOBLR-1156](https://databricks.atlassian.net/browse/PECOBLR-1156)
Part of Story: [PECOBLR-1155](https://databricks.atlassian.net/browse/PECOBLR-1155)
Part of Epic: [PECOBLR-1144](https://databricks.atlassian.net/browse/PECOBLR-1144)

## Design Document
See `DESIGN_MULTI_STATEMENT_TRANSACTIONS.md` for complete technical design.
This implementation follows Section 3.1 (tx struct), Section 4.1 (autoCommit field), Section 4.2 (initialization), and Section 5.1 (error constants).

## Implementation Notes
- Follows JDBC implementation pattern (PR #1060) with client-side autocommit caching
- No user-facing changes in this ticket (structures only)
- Ready for PECOBLR-1157 (BeginTx implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

[PECOBLR-1156]: https://databricks.atlassian.net/browse/PECOBLR-1156
[PECOBLR-1155]: https://databricks.atlassian.net/browse/PECOBLR-1155
[PECOBLR-1144]: https://databricks.atlassian.net/browse/PECOBLR-1144