### PR TITLE
oauth/m2m: make "token fetched successfully" a debug log

### DIFF
--- a/auth/oauth/m2m/m2m.go
+++ b/auth/oauth/m2m/m2m.go
@@ -57,7 +57,7 @@ func (c *authClient) Authenticate(r *http.Request) error {
 
 	c.tokenSource = GetTokenSource(config)
 	token, err := c.tokenSource.Token()
-	log.Info().Msgf("token fetched successfully")
+	log.Debug().Msgf("token fetched successfully")
 	if err != nil {
 		log.Err(err).Msg("failed to get token")
 


### PR DESCRIPTION
The log is quite repetitive, and as we use this sql driver in our customer-facing product where customers see logs, the extra log seems like spam to customers. I think it would be nice to have it as debug log instead of info.