### PR TITLE
Fix int64/uint64 type inference to use BIGINT instead of INTEGER

### DIFF
--- a/parameter_test.go
+++ b/parameter_test.go
@@ -37,6 +37,61 @@ func TestParameter_Inference(t *testing.T) {
 	})
 }
 
+func TestParameter_BigInt(t *testing.T) {
+	t.Run("Should infer int64 as BIGINT", func(t *testing.T) {
+		maxInt64 := int64(9223372036854775807)
+		values := []driver.NamedValue{
+			{Value: maxInt64},
+		}
+		parameters, err := convertNamedValuesToSparkParams(values)
+		require.NoError(t, err)
+		require.Equal(t, "BIGINT", *parameters[0].Type)
+		require.Equal(t, "9223372036854775807", *parameters[0].Value.StringValue)
+	})
+
+	t.Run("Should infer uint64 as BIGINT", func(t *testing.T) {
+		largeUint64 := uint64(0x123456789ABCDEF0)
+		values := []driver.NamedValue{
+			{Value: largeUint64},
+		}
+		parameters, err := convertNamedValuesToSparkParams(values)
+		require.NoError(t, err)
+		require.Equal(t, "BIGINT", *parameters[0].Type)
+		require.Equal(t, "1311768467463790320", *parameters[0].Value.StringValue)
+	})
+
+	t.Run("Should infer negative int64 as BIGINT", func(t *testing.T) {
+		minInt64 := int64(-9223372036854775808)
+		values := []driver.NamedValue{
+			{Value: minInt64},
+		}
+		parameters, err := convertNamedValuesToSparkParams(values)
+		require.NoError(t, err)
+		require.Equal(t, "BIGINT", *parameters[0].Type)
+		require.Equal(t, "-9223372036854775808", *parameters[0].Value.StringValue)
+	})
+
+	t.Run("Should handle explicit BigInt Parameter with non-string value", func(t *testing.T) {
+		values := []driver.NamedValue{
+			{Value: Parameter{Type: SqlBigInt, Value: int64(12345)}},
+		}
+		parameters, err := convertNamedValuesToSparkParams(values)
+		require.NoError(t, err)
+		require.Equal(t, "BIGINT", *parameters[0].Type)
+		require.Equal(t, "12345", *parameters[0].Value.StringValue)
+	})
+
+	t.Run("Should preserve int32 as INTEGER", func(t *testing.T) {
+		values := []driver.NamedValue{
+			{Value: int32(2147483647)},
+		}
+		parameters, err := convertNamedValuesToSparkParams(values)
+		require.NoError(t, err)
+		require.Equal(t, "INTEGER", *parameters[0].Type)
+		require.Equal(t, "2147483647", *parameters[0].Value.StringValue)
+	})
+}
+
 func TestParameters_ConvertToSpark(t *testing.T) {
 	t.Run("Should convert names parameters", func(t *testing.T) {
 		values := [2]driver.NamedValue{

--- a/parameters.go
+++ b/parameters.go
@@ -140,11 +140,11 @@ func inferType(param *Parameter) {
 		param.Value = strconv.FormatUint(uint64(value), 10)
 		param.Type = SqlInteger
 	case int64:
-		param.Value = strconv.Itoa(int(value))
-		param.Type = SqlInteger
+		param.Value = strconv.FormatInt(value, 10)
+		param.Type = SqlBigInt
 	case uint64:
-		param.Value = strconv.FormatUint(uint64(value), 10)
-		param.Type = SqlInteger
+		param.Value = strconv.FormatUint(value, 10)
+		param.Type = SqlBigInt
 	case float32:
 		param.Value = strconv.FormatFloat(float64(value), 'f', -1, 32)
 		param.Type = SqlFloat
@@ -179,7 +179,13 @@ func convertNamedValuesToSparkParams(values []driver.NamedValue) ([]*cli_service
 		if sqlParam.Type == SqlVoid {
 			sparkValue = nil
 		} else {
-			stringValue := sqlParam.Value.(string)
+			var stringValue string
+			switch v := sqlParam.Value.(type) {
+			case string:
+				stringValue = v
+			default:
+				stringValue = fmt.Sprintf("%v", sqlParam.Value)
+			}
 			sparkValue = &cli_service.TSparkParameterValue{StringValue: &stringValue}
 		}
 


### PR DESCRIPTION
## Summary
- Fixes a bug where int64 and uint64 values were incorrectly mapped to SqlInteger instead of SqlBigInt
- Fixes data loss issue where int64 was converted using `strconv.Itoa(int(value))` which truncates large values
- Adds safe type assertion in `convertNamedValuesToSparkParams` to prevent panic when `Parameter.Value` is not a string

## Problem
When inserting int64/uint64 values into BIGINT columns, the driver was sending them with type `INTEGER` instead of `BIGINT`, causing the server to reject large values with error:
```
[INVALID_PARAMETER_MARKER_VALUE.INVALID_VALUE_FOR_DATA_TYPE] An invalid parameter mapping was provided: 
the value '1311768467463790320' for parameter 'null' cannot be cast to INT because it is malformed.
```

## Test plan
- [x] Added unit tests for int64/uint64 type inference (`TestParameter_BigInt`)
- [x] Verified large int64 values are correctly inserted and retrieved from BIGINT columns
- [x] All existing parameter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)