### PR TITLE
Move CI to Databricks protected runners with JFrog OIDC

### DIFF
--- a/.github/actions/setup-jfrog/action.yml
+++ b/.github/actions/setup-jfrog/action.yml
@@ -1,0 +1,35 @@
+name: Setup JFrog OIDC
+description: Obtain a JFrog access token via GitHub OIDC and configure Go to use JFrog as a module proxy
+
+runs:
+  using: composite
+  steps:
+    - name: Get JFrog OIDC token
+      shell: bash
+      run: |
+        set -euo pipefail
+        ID_TOKEN=$(curl -sLS \
+          -H "User-Agent: actions/oidc-client" \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+        echo "::add-mask::${ID_TOKEN}"
+        ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+          "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+        echo "::add-mask::${ACCESS_TOKEN}"
+        if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+          echo "FAIL: Could not extract JFrog access token"
+          exit 1
+        fi
+        echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        echo "JFrog OIDC token obtained successfully"
+
+    - name: Configure Go
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "GOPROXY=https://databricks.jfrog.io/artifactory/api/go/db-golang,direct" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=*" >> "$GITHUB_ENV"
+        printf "machine databricks.jfrog.io\nlogin gha-service-account\npassword %s\n" "${JFROG_ACCESS_TOKEN}" > ~/.netrc
+        chmod 600 ~/.netrc
+        echo "Go configured to use JFrog registry"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   dco-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     name: Check DCO Sign-off
     steps:
       - name: Checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,15 +8,21 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
 
       - name: Set up Go Toolchain
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -33,12 +39,16 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x]
-        os: [ubuntu-latest]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
 
       - name: Set up Go Toolchain
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
## Summary
- Add `.github/actions/setup-jfrog` composite action for OIDC-based JFrog authentication (configures GOPROXY and `.netrc` for Go module proxy)
- Switch all workflow jobs (`lint`, `build-and-test`, `dco-check`) from `ubuntu-latest` to `databricks-protected-runner-group`
- Add `id-token: write` permission for JFrog OIDC token exchange

## Test plan
- [ ] DCO check workflow passes on this PR
- [ ] Lint job passes with Go modules resolved through JFrog proxy
- [ ] Build and test job passes with Go modules resolved through JFrog proxy
- [ ] Verify JFrog OIDC token exchange works on protected runners

This pull request was AI-assisted by Isaac.