### PR TITLE
Prepare for v1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## v1.11.0 (2026-04-16)
+- Enable telemetry by default with DSN-controlled priority (databricks/databricks-sql-go#320, #321, #322, #349)
+- Add SPOG (Custom URL) routing support via `x-databricks-org-id` header (databricks/databricks-sql-go#347)
+- Add statement-level query tag support (databricks/databricks-sql-go#341)
+- Add AI coding agent detection to User-Agent header (databricks/databricks-sql-go#326)
+- Fix CloudFetch returning stale column names from cached results (databricks/databricks-sql-go#351)
+- Fix resource leak: close staging Rows in execStagingOperation (databricks/databricks-sql-go#325)
+
 ## v1.10.0 (2026-02-19)
 - Add token federation / token provider support for OAuth (databricks/databricks-sql-go#290, #291, #292)
 - Internal: add foundational telemetry infrastructure, disabled by default (databricks/databricks-sql-go#297, #304, #305, #311, #319)

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.10.0" // update version before each release
+var DriverVersion = "1.11.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.11.0` and add the v1.11.0 section to `CHANGELOG.md`.

### Changes since v1.10.0
- Enable telemetry by default with DSN-controlled priority (#320, #321, #322, #349)
- Add SPOG (Custom URL) routing support via `x-databricks-org-id` header (#347)
- Add statement-level query tag support (#341)
- Add AI coding agent detection to User-Agent header (#326)
- Fix CloudFetch returning stale column names from cached results (#351)
- Fix resource leak: close staging Rows in execStagingOperation (#325)

Internal/infra-only changes are omitted from the user-facing notes (CI hardening, dependabot bumps, CODEOWNERS).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./... -count=1 -short` passes locally

## Next steps after merge
1. Tag the merge commit as `v1.11.0` and push the tag
2. Trigger `peco-databricks-sql-go` in secure-public-registry-releases-eng with `ref=v1.11.0`, `dry-run=true` to verify
3. Re-run with `dry-run=false` for the actual release

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.