### PR TITLE
Refactor: columnvalues to use strings builder

### DIFF
--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -195,13 +195,14 @@ var _ columnValues = (*listValueContainer)(nil)
 
 func (lvc *listValueContainer) Value(i int) (any, error) {
 	if i < lvc.listArray.Len() {
-		r := "["
+		var sb strings.Builder
+		sb.WriteByte('[')
 		s, e := lvc.listArray.ValueOffsets(i)
 		len := int(e - s)
 
 		for i := 0; i < len; i++ {
 			if lvc.values.IsNull(i + int(s)) {
-				r = r + "null"
+				sb.WriteString("null")
 			} else {
 
 				val, err := lvc.values.Value(i + int(s))
@@ -214,19 +215,19 @@ func (lvc *listValueContainer) Value(i int) (any, error) {
 					if err != nil {
 						return nil, err
 					}
-					r = r + string(vb)
+					sb.Write(vb)
 				} else {
-					r = r + val.(string)
+					sb.WriteString(val.(string))
 				}
 			}
 
 			if i < len-1 {
-				r = r + ","
+				sb.WriteByte(',')
 			}
 		}
 
-		r = r + "]"
-		return r, nil
+		sb.WriteByte(']')
+		return sb.String(), nil
 	}
 	return nil, nil
 }

--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -268,7 +268,8 @@ func (mvc *mapValueContainer) Value(i int) (any, error) {
 	if i < mvc.mapArray.Len() {
 		s, e := mvc.mapArray.ValueOffsets(i)
 		len := e - s
-		r := "{"
+		var sb strings.Builder
+		sb.WriteByte('{')
 		for i := int64(0); i < len; i++ {
 			k, err := mvc.keys.Value(int(i + s))
 			if err != nil {
@@ -285,33 +286,34 @@ func (mvc *mapValueContainer) Value(i int) (any, error) {
 				return nil, err
 			}
 
-			var b string
+			if !strings.HasPrefix(string(key), "\"") {
+				sb.WriteByte('"')
+				sb.Write(key)
+				sb.WriteString("\":")
+			} else {
+				sb.Write(key)
+				sb.WriteByte(':')
+			}
+
 			if mvc.values.IsNull(int(i + s)) {
-				b = "null"
+				sb.WriteString("null")
 			} else if mvc.complexValue {
-				b = v.(string)
+				sb.WriteString(v.(string))
 			} else {
 				vb, err := marshal(v)
 				if err != nil {
 					return nil, err
 				}
-				b = string(vb)
+				sb.Write(vb)
 			}
 
-			if !strings.HasPrefix(string(key), "\"") {
-				r = r + "\"" + string(key) + "\":"
-			} else {
-				r = r + string(key) + ":"
-			}
-
-			r = r + b
 			if i < len-1 {
-				r = r + ","
+				sb.WriteByte(',')
 			}
 		}
-		r = r + "}"
+		sb.WriteByte('}')
 
-		return r, nil
+		return sb.String(), nil
 	}
 	return nil, nil
 }

--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -359,38 +359,38 @@ var _ columnValues = (*structValueContainer)(nil)
 
 func (svc *structValueContainer) Value(i int) (any, error) {
 	if i < svc.structArray.Len() {
-		r := "{"
+		var sb strings.Builder
+		sb.WriteByte('{')
 		for j := range svc.fieldValues {
-			r = r + "\"" + svc.fieldNames[j] + "\":"
+			sb.WriteByte('"')
+			sb.WriteString(svc.fieldNames[j])
+			sb.WriteString("\":")
 
 			if svc.fieldValues[j].IsNull(int(i)) {
-				r = r + "null"
+				sb.WriteString("null")
 			} else {
 				v, err := svc.fieldValues[j].Value(int(i))
 				if err != nil {
 					return nil, err
 				}
 
-				var b string
 				if svc.complexValue[j] {
-					b = v.(string)
+					sb.WriteString(v.(string))
 				} else {
 					vb, err := marshal(v)
 					if err != nil {
 						return nil, err
 					}
-					b = string(vb)
+					sb.Write(vb)
 				}
-
-				r = r + b
 			}
 			if j < len(svc.fieldValues)-1 {
-				r = r + ","
+				sb.WriteByte(',')
 			}
 		}
-		r = r + "}"
+		sb.WriteByte('}')
 
-		return r, nil
+		return sb.String(), nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Replace repeated string concatenation with strings.Builder in complex type Value() methods to improve performance.

## Problem

listValueContainer, mapValueContainer, and structValueContainer build strings using + inside loops, resulting in O(n^2) time complexity.

In cases like COLLECT_SET(...) returning many elements, this can make rows.Next() / rows.Scan() hang, with most time spent in runtime.concatstring2.

## Observed Workaround

Changing the SQL from COLLECT_SET() (array type) to ARRAY_JOIN(COLLECT_SET(...), '\n') (string type) bypasses the problem because the driver reads the column as a plain string value, avoiding calls to the complex type Value() methods.

## Fix

Use strings.Builder for string construction in all three Value() methods, which reduces time complexity from O(n^2) to O(n).

## Testing

Pre-existing unit tests passed, no tests added.

## Notes

No behavioral changes, output format identical.

Signed-off-by: Michael Yen <29710093+micyen@users.noreply.github.com>
