### PR TITLE
Prepare for v1.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## v1.11.1 (2026-05-20)
+- Fix CloudFetch goroutine leak that retained Arrow buffers after Close (databricks/databricks-sql-go#357)
+
 ## v1.11.0 (2026-04-16)
 - Enable telemetry by default with DSN-controlled priority (databricks/databricks-sql-go#320, #321, #322, #349)
 - Add SPOG (Custom URL) routing support via `x-databricks-org-id` header (databricks/databricks-sql-go#347)

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.11.0" // update version before each release
+var DriverVersion = "1.11.1" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.11.1` and add the `v1.11.1` section to `CHANGELOG.md`.

### Notable changes since v1.11.0
- Fix CloudFetch goroutine leak that retained Arrow buffers after Close (databricks/databricks-sql-go#357)

## Test plan
- [x] `go test ./... -count=1 -short` passes locally
- [x] Multi-DBR tests in `universe/peco/correctness/go` passed (5/5 suites on DBR 18.x-photon-scala2.13)
- [ ] CI green

This pull request was AI-assisted by Isaac.