### PR TITLE
rows/rowscanner: set isFinished=true when last page has no more rows

### DIFF
--- a/internal/rows/rowscanner/resultPageIterator.go
+++ b/internal/rows/rowscanner/resultPageIterator.go
@@ -134,6 +134,7 @@ func (rpf *resultPageIterator) HasNext() bool {
 		rpf.err = nil
 		rpf.nextResultPage = nrp
 		if !nrp.GetHasMoreRows() {
+			rpf.isFinished = true
 			rpf.Close() //nolint:errcheck,gosec // G104: close in error path
 		}
 	}


### PR DESCRIPTION
## Problem

In `resultPageIterator.HasNext()`, when a fetched page has `HasMoreRows == false`,
the code calls `rpf.Close()` to close the operation handle on the server but never
sets `rpf.isFinished = true`.

After `Next()` consumes that last page and clears `nextResultPage`, any subsequent
call to `HasNext()` bypasses the early-exit guard at the top of the function
(which checks `isFinished && nextResultPage == nil`) and falls through to
`getNextPage()`. Since `isFinished` is still `false`, `getNextPage()` proceeds to
issue a `FetchResults` RPC against an already-closed operation handle, resulting
in a spurious server-side error instead of a clean `io.EOF`.

## Fix

Set `rpf.isFinished = true` alongside `rpf.Close()` in the no-more-rows branch,
mirroring what the error path in the same function already does correctly:

```go
// before
if !nrp.GetHasMoreRows() {
    rpf.Close()
}

// after
if !nrp.GetHasMoreRows() {
    rpf.isFinished = true
    rpf.Close()
}
```

## Impact

Any caller that invokes `HasNext()` more than once after the last page is consumed
— a reasonable and common pattern — would previously receive an unexpected RPC
error. After this fix they receive `false` / `io.EOF` as intended.