### PR TITLE
[SIRT-1753] Bump go-jose/go-jose/v3 to v3.0.5 (CVE-2026-34986)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4Nij
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
-github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
-github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
## Summary

Addresses [SIRT-1753](https://databricks.atlassian.net/browse/SIRT-1753) by bumping the transitive `github.com/go-jose/go-jose/v3` dependency from `v3.0.4` to `v3.0.5`, which patches **CVE-2026-34986** (JWE `KeyUnwrap` panic → DoS).

- `go-jose` is an indirect dependency pulled in via `coreos/go-oidc/v3`.
- The vulnerable code path (`ParseEncrypted*` → `Decrypt`) is never reached by this driver — `go-oidc` is used only for OIDC provider discovery (fetching `.well-known/openid-configuration`).
- The bump is to satisfy SCA scanners; it is not a functional change.

## Scope note: CVE-2026-41602 (apache/thrift) is intentionally **not** included

SIRT-1753 also flags `github.com/apache/thrift v0.17.0` for **CVE-2026-41602** (TFramedTransport integer overflow). This PR does **not** bump thrift, for two reasons:

1. **The upstream fix only lands in `apache/thrift v0.23.0`**, which requires **Go 1.25**. This module's `go.mod` is pinned to `go 1.20`. Bumping the go directive to 1.25 would force every downstream consumer on Go 1.20–1.24 to upgrade their build toolchain — a breaking change inappropriate for a security patch release.
2. **The vulnerable component is not reachable.** Per [Ricardo's analysis on SIRT-1753](https://databricks.atlassian.net/browse/SIRT-1753), the driver only uses `THttpClient` (see `internal/client/client.go:283` and the hardcoded `ThriftTransport: "http"` default in `internal/config/config.go`). `TFramedTransport` is never instantiated — there is no code path, even a fallback, that constructs it.

The non-exploitability of CVE-2026-41602 will be communicated back to SIRT (VEX / suppression) rather than addressed via a toolchain bump. We can revisit when the driver's Go floor moves as part of a planned, communicated minor release.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass

This pull request and its description were written by Isaac.

[SIRT-1753]: https://databricks.atlassian.net/browse/SIRT-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ