### PR TITLE
Prepare for v1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## v1.12.0 (2026-05-25)
+- Retry transient S3 errors in CloudFetch downloads and staging PUT/GET/REMOVE operations (databricks/databricks-sql-go#355, #361)
+- Telemetry: normalize host key for per-host client + breaker registries; stop retrying into 429s, honour Retry-After, fix userAgent (databricks/databricks-sql-go#354, #364)
+- Bump dependencies to clear Go-1.20-compatible CVEs: golang-jwt, x/net, protobuf, go-jose v3.0.5 (CVE-2026-34986) (databricks/databricks-sql-go#360, #363)
+
 ## v1.11.1 (2026-05-20)
 - Fix CloudFetch goroutine leak that retained Arrow buffers after Close (databricks/databricks-sql-go#357)
 

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.11.1" // update version before each release
+var DriverVersion = "1.12.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.12.0` and add the `v1.12.0` section to `CHANGELOG.md`.

### Notable changes since v1.11.1
- Retry transient S3 errors in CloudFetch downloads and staging PUT/GET/REMOVE operations (#355, #361)
- Telemetry: normalize host key for per-host client + breaker registries; stop retrying into 429s, honour Retry-After, fix userAgent (#354, #364)
- Bump dependencies to clear Go-1.20-compatible CVEs: golang-jwt, x/net, protobuf, go-jose v3.0.5 (CVE-2026-34986) (#360, #363)

## Test plan
- [x] `go test ./... -count=1 -short` passes locally
- [x] Multi-DBR tests in `universe/peco/correctness/go` passed (all 5 suites green against DBR 18.x-photon-scala2.13)
- [ ] CI green

This pull request was AI-assisted by Isaac.