### PR TITLE
Extract SPOG org-id from cluster httpPath for non-Thrift requests

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -139,7 +139,10 @@ func NewConnector(options ...ConnOption) (driver.Connector, error) {
 
 // clusterPathOrgIDPattern matches the workspace ID inside an all-purpose-compute
 // Thrift path of the form [/]sql/protocolv1/o/<workspace-id>/<cluster-id>[/...].
-var clusterPathOrgIDPattern = regexp.MustCompile(`(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+`)
+var (
+	orgIDPattern            = regexp.MustCompile(`^[0-9]+$`)
+	clusterPathOrgIDPattern = regexp.MustCompile(`^/?sql/protocolv1/o/([0-9]+)/[^/?]+`)
+)
 
 // extractSpogHeaders inspects httpPath for the workspace ID and returns it as an
 // x-databricks-org-id header dict for SPOG routing.
@@ -170,10 +173,15 @@ func extractSpogHeaders(httpPath string) map[string]string {
 				"SPOG header extraction: malformed query string in httpPath, falling back to path inspection: %s",
 				err)
 		} else if orgID := params.Get("o"); orgID != "" {
-			logger.Debug().Msgf(
-				"SPOG header extraction: injecting x-databricks-org-id=%s (extracted from ?o= in httpPath)",
-				orgID)
-			return map[string]string{"x-databricks-org-id": orgID}
+			if !orgIDPattern.MatchString(orgID) {
+				logger.Debug().Msg(
+					"SPOG header extraction: ignoring non-numeric ?o= value in httpPath, falling back to path inspection")
+			} else {
+				logger.Debug().Msgf(
+					"SPOG header extraction: injecting x-databricks-org-id=%s (extracted from ?o= in httpPath)",
+					orgID)
+				return map[string]string{"x-databricks-org-id": orgID}
+			}
 		}
 	}
 

--- a/connector.go
+++ b/connector.go
@@ -82,11 +82,11 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 	log := logger.WithContext(conn.id, driverctx.CorrelationIdFromContext(ctx), "")
 
-	// Extract SPOG routing headers from ?o= in HTTPPath. When ?o=<workspaceId>
-	// is present (Custom URL / SPOG hosts), wrap the HTTP client used for
-	// telemetry + feature-flag calls with a transport that injects
-	// x-databricks-org-id. Thrift routes via the URL so its own c.client
-	// doesn't need wrapping.
+	// Extract SPOG routing headers from HTTPPath. When the workspace ID is
+	// available via ?o=<workspaceId> or a cluster /o/<workspaceId>/ path segment,
+	// wrap the HTTP client used for telemetry + feature-flag calls with a
+	// transport that injects x-databricks-org-id. Thrift routes via the URL so
+	// its own c.client doesn't need wrapping.
 	telemetryClient := c.client
 	if spogHeaders := extractSpogHeaders(c.cfg.HTTPPath); len(spogHeaders) > 0 {
 		telemetryClient = withSpogHeaders(c.client, spogHeaders)

--- a/connector.go
+++ b/connector.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -136,44 +137,59 @@ func NewConnector(options ...ConnOption) (driver.Connector, error) {
 	return &connector{cfg: cfg, client: client}, nil
 }
 
-// extractSpogHeaders extracts ?o=<workspaceId> from httpPath and returns
-// an x-databricks-org-id header for SPOG routing.
+// clusterPathOrgIDPattern matches the workspace ID inside an all-purpose-compute
+// Thrift path of the form [/]sql/protocolv1/o/<workspace-id>/<cluster-id>[/...].
+var clusterPathOrgIDPattern = regexp.MustCompile(`(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+`)
+
+// extractSpogHeaders inspects httpPath for the workspace ID and returns it as an
+// x-databricks-org-id header dict for SPOG routing.
 //
-// On SPOG (Custom URL) workspaces, httpPath is of the form
-// /sql/1.0/warehouses/<id>?o=<workspaceId>. The ?o= parameter keeps Thrift
-// requests routed to the correct workspace via the URL itself, but other
-// endpoints (telemetry, feature flags) run on separate hosts and need the
-// x-databricks-org-id header. This function extracts ?o= from httpPath once
-// and returns it so those paths can inject it as an HTTP header.
+// Two sources are checked, in priority order:
+//  1. ?o=<workspace-id> query parameter (warehouse paths on SPOG typically use
+//     this form, e.g. /sql/1.0/warehouses/<id>?o=<workspace-id>).
+//  2. /sql/protocolv1/o/<workspace-id>/<cluster-id> path segment (all-purpose
+//     cluster paths embed the workspace in the path itself).
 //
-// Returns nil if:
-//   - httpPath has no query string ("?"), or
-//   - the query string is malformed and can't be parsed, or
-//   - the ?o= parameter is missing or empty.
+// Thrift requests are routed by the URL itself, but other endpoints
+// (telemetry, feature flags) run on separate paths that don't carry the
+// workspace ID — without this header, PoPP on SPOG hosts can't determine the
+// workspace and redirects the request to /login.
+//
+// Returns nil if no workspace ID can be determined.
 func extractSpogHeaders(httpPath string) map[string]string {
-	if !strings.Contains(httpPath, "?") {
+	if httpPath == "" {
 		return nil
 	}
-	// Parse query string from httpPath
-	parts := strings.SplitN(httpPath, "?", 2)
-	params, err := url.ParseQuery(parts[1])
-	if err != nil {
+
+	// 1) ?o=<wsid> query parameter.
+	if strings.Contains(httpPath, "?") {
+		parts := strings.SplitN(httpPath, "?", 2)
+		params, err := url.ParseQuery(parts[1])
+		if err != nil {
+			logger.Debug().Msgf(
+				"SPOG header extraction: malformed query string in httpPath, falling back to path inspection: %s",
+				err)
+		} else if orgID := params.Get("o"); orgID != "" {
+			logger.Debug().Msgf(
+				"SPOG header extraction: injecting x-databricks-org-id=%s (extracted from ?o= in httpPath)",
+				orgID)
+			return map[string]string{"x-databricks-org-id": orgID}
+		}
+	}
+
+	// 2) /sql/protocolv1/o/<wsid>/<cluster> path segment.
+	if match := clusterPathOrgIDPattern.FindStringSubmatch(httpPath); match != nil {
+		orgID := match[1]
 		logger.Debug().Msgf(
-			"SPOG header extraction: malformed query string in httpPath, skipping org-id extraction: %s",
-			err)
-		return nil
+			"SPOG header extraction: injecting x-databricks-org-id=%s (extracted from cluster path segment)",
+			orgID)
+		return map[string]string{"x-databricks-org-id": orgID}
 	}
-	orgID := params.Get("o")
-	if orgID == "" {
-		logger.Debug().Msg(
-			"SPOG header extraction: httpPath has query string but no ?o= param, " +
-				"skipping x-databricks-org-id injection")
-		return nil
-	}
-	logger.Debug().Msgf(
-		"SPOG header extraction: injecting x-databricks-org-id=%s (extracted from ?o= in httpPath)",
-		orgID)
-	return map[string]string{"x-databricks-org-id": orgID}
+
+	logger.Debug().Msg(
+		"SPOG header extraction: no workspace ID found in httpPath, " +
+			"skipping x-databricks-org-id injection")
+	return nil
 }
 
 // withSpogHeaders returns a new *http.Client that reuses the transport of the

--- a/connector_spog_test.go
+++ b/connector_spog_test.go
@@ -48,9 +48,24 @@ func TestExtractSpogHeaders(t *testing.T) {
 			want:     map[string]string{"x-databricks-org-id": "12345"},
 		},
 		{
-			name:     "first o= wins when duplicated",
-			httpPath: "/sql/1.0/warehouses/abc?o=first&o=second",
-			want:     map[string]string{"x-databricks-org-id": "first"},
+			name:     "first numeric o= wins when duplicated",
+			httpPath: "/sql/1.0/warehouses/abc?o=111&o=222",
+			want:     map[string]string{"x-databricks-org-id": "111"},
+		},
+		{
+			name:     "non-numeric o= value returns nil",
+			httpPath: "/sql/1.0/warehouses/abc?o=abc123",
+			want:     nil,
+		},
+		{
+			name:     "control-character o= value returns nil",
+			httpPath: "/sql/1.0/warehouses/abc?o=123%0D%0AX-Injected:%20yes",
+			want:     nil,
+		},
+		{
+			name:     "invalid o= falls back to valid cluster path segment",
+			httpPath: "sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt?o=abc123",
+			want:     map[string]string{"x-databricks-org-id": "6051921418418893"},
 		},
 		{
 			name:     "just ? with nothing after returns nil",
@@ -74,6 +89,21 @@ func TestExtractSpogHeaders(t *testing.T) {
 			name:     "?o= query param wins over cluster path segment",
 			httpPath: "sql/protocolv1/o/111/0528-220959-uzmcn1qt?o=222",
 			want:     map[string]string{"x-databricks-org-id": "222"},
+		},
+		{
+			name:     "nested cluster path prefix returns nil",
+			httpPath: "evil/sql/protocolv1/o/999/0528-220959-uzmcn1qt",
+			want:     nil,
+		},
+		{
+			name:     "incomplete cluster path returns nil",
+			httpPath: "sql/protocolv1/o/999/",
+			want:     nil,
+		},
+		{
+			name:     "warehouse path containing cluster-looking suffix returns nil",
+			httpPath: "/sql/1.0/warehouses/sql/protocolv1/o/999/cluster-id",
+			want:     nil,
 		},
 		{
 			// Regression guard: the new cluster-path regex must not match

--- a/connector_spog_test.go
+++ b/connector_spog_test.go
@@ -57,6 +57,31 @@ func TestExtractSpogHeaders(t *testing.T) {
 			httpPath: "/sql/1.0/warehouses/abc?",
 			want:     nil,
 		},
+		{
+			// All-purpose cluster paths embed the workspace ID in /o/<wsid>/<cluster>.
+			// Without ?o=, the driver must still extract it so non-Thrift endpoints
+			// (telemetry, feature flags) get x-databricks-org-id on SPOG hosts.
+			name:     "cluster path without ?o= extracts org id from path segment",
+			httpPath: "sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt",
+			want:     map[string]string{"x-databricks-org-id": "6051921418418893"},
+		},
+		{
+			name:     "cluster path with leading slash also extracts",
+			httpPath: "/sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt",
+			want:     map[string]string{"x-databricks-org-id": "6051921418418893"},
+		},
+		{
+			name:     "?o= query param wins over cluster path segment",
+			httpPath: "sql/protocolv1/o/111/0528-220959-uzmcn1qt?o=222",
+			want:     map[string]string{"x-databricks-org-id": "222"},
+		},
+		{
+			// Regression guard: the new cluster-path regex must not match
+			// warehouse paths (which never embed the workspace ID).
+			name:     "warehouse path without ?o= still returns nil",
+			httpPath: "/sql/1.0/warehouses/abc123",
+			want:     nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/connector_spog_test.go
+++ b/connector_spog_test.go
@@ -136,6 +136,29 @@ func TestHeaderInjectingTransport_DoesNotOverrideCallerSet(t *testing.T) {
 	assert.Equal(t, "from-caller", gotHeader, "caller-set header must not be overridden")
 }
 
+func TestHeaderInjectingTransport_DoesNotOverrideCallerSetMixedCase(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("x-databricks-org-id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := withSpogHeaders(&http.Client{}, map[string]string{
+		"x-databricks-org-id": "from-wrapper",
+	})
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Databricks-Org-Id", "from-caller")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, "from-caller", gotHeader, "caller-set header must not be overridden")
+}
+
 func TestHeaderInjectingTransport_PreservesOtherHeaders(t *testing.T) {
 	var gotAuth, gotSpog, gotCustom string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Fixes silent telemetry loss on SPOG (custom-URL) hosts when connecting to an all-purpose cluster via an httpPath like `sql/protocolv1/o/<workspace-id>/<cluster-id>`.
- `extractSpogHeaders` now extracts the workspace ID from the `/o/<wsid>/` path segment as a fallback when `?o=<wsid>` is not present, and emits an `x-databricks-org-id` header so the wrapped `telemetryClient` / feature-flag client can route correctly on SPOG.
- Priority order preserved: `?o=` in `httpPath` ▶ `/sql/protocolv1/o/<wsid>/` path segment. Caller-set request headers still win, including mixed-case `X-Databricks-Org-Id`.

## Why

On a SPOG host the workspace identity has to be in either the URL or the `x-databricks-org-id` header for PoPP to route a request to the correct workspace. For all-purpose cluster Thrift this is free — the workspace ID is in the `/o/<wsid>/` segment of httpPath, so PoPP routes Thrift via `routing_reason=workspace-id` and the session opens fine without an explicit `?o=`.

The telemetry and feature-flag transports built by `connector.Connect` wrap `c.client` with `withSpogHeaders` only when `extractSpogHeaders(c.cfg.HTTPPath)` returns a non-nil map. Before this PR that only happened when `?o=` was present, so cluster URLs without `?o=` produced no `x-databricks-org-id` header, PoPP fell back to default (account) routing on `/telemetry-ext`, and the responses were 303 redirects to `/login` — silently dropping telemetry on SPOG.

## What changes

`connector.go`
- New `clusterPathOrgIDPattern` regex (`(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+`) compiled once at package init.
- `extractSpogHeaders` checks `?o=` first (existing behavior), then falls back to the cluster path segment, then returns nil. The malformed-query-string path now also falls through to path inspection instead of returning early. Log messages indicate which source produced the workspace ID.
- Updated the connection comment to describe both query-param and cluster-path extraction.
- `regexp` added to imports.

`connector_spog_test.go`
- Four new table entries under `TestExtractSpogHeaders`:
  - Cluster path without `?o=` → header extracted from `/o/<wsid>/`
  - Cluster path with leading `/` → same
  - Cluster path with `?o=` → query-param value wins
  - Warehouse path without `?o=` → still nil (regression guard: the new regex must not match warehouse paths)
- New transport regression test proving a mixed-case caller-set `X-Databricks-Org-Id` is not overwritten by the SPOG wrapper.

## Test plan

- [x] `go test -run 'TestExtractSpogHeaders|TestHeaderInjectingTransport' -v .` — focused SPOG extraction and transport tests pass.
- [x] `go test -short .` — root package suite passes.
- [x] Behavior validated on the OSS JDBC equivalent fix against Prod SPOG (`peco.azuredatabricks.net`) all-purpose cluster: telemetry POST `/telemetry-ext` flipped from `HTTP 303 → /login` to `HTTP 200 OK` once the path-segment extraction populated `x-databricks-org-id`. Same shape of fix here.

## Out of scope

- The corresponding OSS JDBC driver fix is opened as databricks/databricks-jdbc#1475.
- The Python connector (`databricks/databricks-sql-python`) has a sibling upstream-head PR for the same fix: databricks/databricks-sql-python#817.
- The Node.js connector (`databricks/databricks-sql-nodejs`) already extracts org ID from both query param and path segment (see `extractWorkspaceId` in `lib/DBSQLClient.ts`).

This pull request and its description were written with assistance from Claude Code.