### PR TITLE
Fix flaky TestConn_ExecContext: don't cancel a finished operation

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1576,11 +1576,20 @@ func TestConn_ExecContext(t *testing.T) {
 		ctx, cancel = context.WithCancel(ctx)
 		defer cancel()
 		res, err := testConn.ExecContext(ctx, "insert 10", []driver.NamedValue{})
-		assert.Error(t, err)
-		assert.Nil(t, res)
+		// GetOperationStatus reports FINISHED in the same call that cancels the
+		// context. Because the operation completed, the sentinel must report
+		// success and must NOT cancel a finished operation, regardless of
+		// scheduler timing — this assertion previously raced on cancelOperationCount.
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		rowsAffected, _ := res.RowsAffected()
+		assert.Equal(t, int64(10), rowsAffected)
 		assert.Equal(t, 1, executeStatementCount)
-		assert.Equal(t, 1, cancelOperationCount)
+		assert.Equal(t, 0, cancelOperationCount)
 		assert.Equal(t, 1, getOperationStatusCount)
+		// CloseOperation must still run, on a fresh (non-cancelled) context, even
+		// though the context passed to ExecContext was cancelled mid-poll. Its
+		// FnCloseOperation asserts ctx.Err() == nil.
 		assert.Equal(t, 1, closeOperationCount)
 	})
 }

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -114,10 +114,16 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 			if done() {
 				intervalTimer.Stop()
 				if s.OnDoneFn != nil {
+					// The operation has completed, so the OnDoneFn result is the
+					// authoritative outcome. Run the processor and drain its
+					// result without selecting on ctx.Done()/timeout: once we've
+					// observed completion, a concurrent cancellation or timeout
+					// must not race the success path and trigger an unnecessary
+					// cancel of a finished operation.
 					go processor(statusResp)
-				} else {
-					return WatchSuccess, statusResp, nil
+					return s.waitForDone(resCh, errCh)
 				}
+				return WatchSuccess, statusResp, nil
 			}
 		case err := <-errCh:
 			return WatchErr, nil, err
@@ -134,5 +140,18 @@ func (s Sentinel) Watch(ctx context.Context, interval, timeout time.Duration) (W
 			err := errors.New(msg)
 			return WatchTimeout, nil, err
 		}
+	}
+}
+
+// waitForDone blocks until the asynchronous OnDoneFn processor reports its
+// result. The operation has already been observed as complete by the time this
+// is called, so the outcome is determined solely by OnDoneFn and is no longer
+// subject to cancellation or timeout.
+func (s Sentinel) waitForDone(resCh chan any, errCh chan error) (WatchStatus, any, error) {
+	select {
+	case err := <-errCh:
+		return WatchErr, nil, err
+	case res := <-resCh:
+		return WatchSuccess, res, nil
 	}
 }

--- a/internal/sentinel/sentinel_test.go
+++ b/internal/sentinel/sentinel_test.go
@@ -257,6 +257,49 @@ func TestWatch(t *testing.T) {
 		assert.Nil(t, res)
 		assert.ErrorContains(t, err, "failed")
 	})
+	t.Run("it should not cancel when context is canceled concurrently with Done", func(t *testing.T) {
+		// Regression test for a race where, once StatusFn reports Done, a
+		// context cancellation that arrives at the same time could win the
+		// select against the OnDoneFn result and trigger OnCancelFn for an
+		// operation that has already completed. A finished operation must
+		// never be canceled, regardless of scheduler timing.
+		//
+		// We pre-cancel the context and report Done in the same StatusFn call,
+		// so both the success path and ctx.Done() are ready when Watch
+		// re-enters its select. The outcome must deterministically be success
+		// with no cancellation, on every run.
+		//
+		// A tiny non-zero interval keeps each iteration to microseconds (a 0
+		// interval would default to 100ms and make the loop take many seconds).
+		// The fix makes the outcome deterministic, so a modest iteration count
+		// is enough to guard against regression cheaply.
+		for i := 0; i < 100; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancelFnCalls := 0
+			s := Sentinel{
+				StatusFn: func() (Done, any, error) {
+					// Cancel the context right as we report completion.
+					cancel()
+					return func() bool {
+						return true
+					}, "completed", nil
+				},
+				OnCancelFn: func() (any, error) {
+					cancelFnCalls++
+					return nil, nil
+				},
+				OnDoneFn: func(statusResp any) (any, error) {
+					return statusResp, nil
+				},
+			}
+			status, res, err := s.Watch(ctx, time.Microsecond, 0)
+			assert.Equal(t, WatchSuccess, status)
+			assert.Equal(t, "completed", res)
+			assert.Equal(t, 0, cancelFnCalls, "OnCancelFn must not be called for a completed operation (iteration %d)", i)
+			assert.NoError(t, err)
+			cancel()
+		}
+	})
 	t.Run("it should return statusFn error", func(t *testing.T) {
 		statusFnCalls := 0
 		cancelFnCalls := 0


### PR DESCRIPTION
## Problem

`TestConn_ExecContext/"ExecContext uses new context to close operation"` is flaky in CI. On Go 1.26 it fails with `cancelOperationCount expected 1, got 0`; the same race surfaces on Go 1.20 too — it just biases the other way. The Go scheduler version only changes the *probability*; the race is in the design, not the language version.

## Root cause

In `internal/sentinel/sentinel.go`, the `Watch` loop has a race once `StatusFn` reports `Done`:

```go
if done() {
    intervalTimer.Stop()
    if s.OnDoneFn != nil {
        go processor(statusResp)   // sends to resCh asynchronously
    } else { ... }
}
// ...loops back into select with BOTH resCh and ctx.Done() potentially ready
```

When `OnDoneFn` is set (always, in production `pollOperation`), the `done()` branch spawns the processor and falls back into the `select`. Two cases can now be ready at the same instant — `<-resCh` (success) and `<-ctx.Done()` (cancel) — and Go's `select` chooses **randomly**. If `ctx.Done()` wins, `OnCancelFn` fires and cancels an operation that has *already finished*.

The test cancels the context inside `GetOperationStatus` while returning `FINISHED`, then asserted `cancelOperationCount == 1` — i.e. it asserted on the losing side of that random select.

## Fix

Once `done()` is observed, the operation has logically completed and the `OnDoneFn` result is the authoritative outcome. Drain it via a new `waitForDone` helper that selects only on `resCh`/`errCh` — no longer on `ctx.Done()`/timeout. **A finished operation is now never cancelled, deterministically.**

## Tests

- Updated the connection test to assert the correct, deterministic behaviour: success, `cancelOperationCount == 0`, and `CloseOperation` still runs on a fresh (non-cancelled) context — which is exactly what the test's name claims to verify.
- Added a sentinel regression test that pre-cancels the context in the same `StatusFn` call that reports `Done`. It uses a microsecond interval and 100 iterations, so it runs in ~0s and adds no meaningful CI time.

## Verification

- `go test -run 'TestConn_ExecContext$' -count=300` → green (previously flaked under stress).
- `go test -race -run TestWatch ./internal/sentinel/ -count=5` → green (no data race).