### PR TITLE
fix: lossless decimal decode (fixes float64 precision loss) + reachable native-decimal opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Release History
 
-## Unreleased
-- Add native Arrow decimal support, opt-in via `WithUseArrowNativeDecimal(true)`. DECIMAL columns are decoded from native Arrow decimal128 values as a lossless decimal string, preserving full precision and scale. The default remains unchanged (decimals are still returned as strings), so this is a non-breaking, opt-in change.
-
 ## v1.12.0 (2026-05-25)
 - Retry transient S3 errors in CloudFetch downloads and staging PUT/GET/REMOVE operations (databricks/databricks-sql-go#355, #361)
 - Telemetry: normalize host key for per-host client + breaker registries; stop retrying into 429s, honour Retry-After, fix userAgent (databricks/databricks-sql-go#354, #364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Unreleased
+- Add native Arrow decimal support, opt-in via `WithUseArrowNativeDecimal(true)`. DECIMAL columns are decoded from native Arrow decimal128 values as a lossless decimal string, preserving full precision and scale. The default remains unchanged (decimals are still returned as strings), so this is a non-breaking, opt-in change.
+
 ## v1.12.0 (2026-05-25)
 - Retry transient S3 errors in CloudFetch downloads and staging PUT/GET/REMOVE operations (databricks/databricks-sql-go#355, #361)
 - Telemetry: normalize host key for per-host client + breaker registries; stop retrying into 429s, honour Retry-After, fix userAgent (databricks/databricks-sql-go#354, #364)

--- a/connector.go
+++ b/connector.go
@@ -409,6 +409,18 @@ func WithCloudFetch(useCloudFetch bool) ConnOption {
 	}
 }
 
+// WithUseArrowNativeDecimal enables native Arrow decimal support. Default is false.
+// When enabled, DECIMAL columns retrieved over Arrow batches are decoded as
+// native Arrow decimal128 values and returned as a lossless decimal string
+// (e.g. "123.45"), preserving full precision and scale. When disabled (the
+// default), decimals are returned as strings via the non-native path, so the
+// observable Go type is the same either way.
+func WithUseArrowNativeDecimal(enable bool) ConnOption {
+	return func(c *config.Config) {
+		c.UseArrowNativeDecimal = enable
+	}
+}
+
 // WithMaxDownloadThreads sets up maximum download threads for cloud fetch. Default is 10.
 func WithMaxDownloadThreads(numThreads int) ConnOption {
 	return func(c *config.Config) {

--- a/doc.go
+++ b/doc.go
@@ -363,7 +363,7 @@ DATE --> time.Time
 
 TIMESTAMP --> time.Time
 
-DECIMAL(p,s) --> sql.RawBytes
+DECIMAL(p,s) --> string
 
 BINARY --> sql.RawBytes
 

--- a/internal/rows/arrowbased/arrowRows.go
+++ b/internal/rows/arrowbased/arrowRows.go
@@ -218,10 +218,11 @@ func (ars *arrowRowScanner) ScanRow(
 			col := ars.colInfo[i]
 			dbType := col.dbType
 
-			if (dbType == cli_service.TTypeId_DECIMAL_TYPE && ars.UseArrowNativeDecimal) ||
-				(isIntervalType(dbType) && ars.UseArrowNativeIntervalTypes) {
-				//	not yet fully supported
-				ars.Error().Msgf(errArrowRowsUnsupportedNativeType(dbType.String()))
+			// Decimal types are supported natively (returned as a lossless string
+			// via decimal128Container). Only interval types remain unsupported.
+			if isIntervalType(dbType) && ars.UseArrowNativeIntervalTypes {
+				//	interval types are not yet fully supported
+				ars.Error().Msg(errArrowRowsUnsupportedNativeType(dbType.String()))
 				return dbsqlerrint.NewDriverError(ars.ctx, errArrowRowsUnsupportedNativeType(dbType.String()), nil)
 			}
 

--- a/internal/rows/arrowbased/arrowRows_test.go
+++ b/internal/rows/arrowbased/arrowRows_test.go
@@ -887,7 +887,10 @@ func TestArrowRowScanner(t *testing.T) {
 
 			err := ars.ScanRow(dest, 0)
 
-			if i < 3 {
+			// Columns are ordered: 0=array, 1=map, 2=struct, 3=decimal,
+			// 4=interval_ym, 5=interval_dt. Complex types (0-2) and decimal (3)
+			// are supported natively; only the interval types (4-5) still error.
+			if i < 4 {
 				assert.Nil(t, err)
 			} else {
 				assert.NotNil(t, err)
@@ -1274,7 +1277,7 @@ func TestArrowRowScanner(t *testing.T) {
 			"[[1,2,3],[4,5,6],null]",
 			"[{\"key1\":1,\"key2\":2},{\"key3\":3,\"key4\":4},null]",
 			"[{\"Field1\":77,\"Field2\":\"2020-12-31 00:00:00 +0000 UTC\"},{\"Field1\":13,\"Field2\":\"-2020-12-31 00:00:00 +0000 UTC\"},{\"Field1\":null,\"Field2\":null}]",
-			"[5.15,123.45,null]",
+			"[\"5.15\",\"123.45\",null]",
 			"[\"2020-12-31 00:00:00 +0000 UTC\",\"-2020-12-31 00:00:00 +0000 UTC\",null]",
 		}
 

--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -521,9 +521,17 @@ type decimal128Container struct {
 var _ columnValues = (*decimal128Container)(nil)
 
 func (tvc *decimal128Container) Value(i int) (any, error) {
+	if tvc.decimalArray.IsNull(i) {
+		return nil, nil
+	}
 	dv := tvc.decimalArray.Value(i)
-	fv := dv.ToFloat64(tvc.scale)
-	return fv, nil
+	// Return the decimal as a lossless string. float64 cannot exactly
+	// represent high-precision/high-scale decimals, so converting here would
+	// silently lose precision for the very type users reach for to avoid that.
+	// Returning a string also matches the non-native default path and the
+	// column-based transport, so the Go type is consistent regardless of how
+	// the server chooses to send the result.
+	return dv.ToString(tvc.scale), nil
 }
 
 func (tvc *decimal128Container) IsNull(i int) bool {

--- a/internal/rows/arrowbased/columnValues_test.go
+++ b/internal/rows/arrowbased/columnValues_test.go
@@ -68,3 +68,49 @@ func TestDecimal128ContainerValue(t *testing.T) {
 		})
 	}
 }
+
+// TestDecimal128NestedInListPreservesPrecision guards the DEFAULT path: complex
+// types are native by default (UseArrowNativeComplexTypes=true), so a decimal
+// nested inside an ARRAY/STRUCT is decoded by decimal128Container even when the
+// top-level UseArrowNativeDecimal flag is off. Before the lossless-string fix
+// this path went through ToFloat64 and silently corrupted high-precision values
+// (and rendered SQL NULL as the number 0). This test pins the lossless behavior.
+func TestDecimal128NestedInListPreservesPrecision(t *testing.T) {
+	const precision, scale int32 = 38, 18
+	const highPrecision = "12345678901234567890.123456789012345678"
+
+	mem := memory.NewGoAllocator()
+	elemType := &arrow.Decimal128Type{Precision: precision, Scale: scale}
+	lb := array.NewListBuilder(mem, elemType)
+	defer lb.Release()
+	vb := lb.ValueBuilder().(*array.Decimal128Builder)
+
+	// One list: [highPrecision, NULL, "3.300000000000000000"]
+	lb.Append(true)
+	for _, s := range []string{highPrecision, "", "3.30"} {
+		if s == "" {
+			vb.AppendNull()
+			continue
+		}
+		num, err := decimal128.FromString(s, precision, scale)
+		require.NoError(t, err)
+		vb.Append(num)
+	}
+
+	listArr := lb.NewListArray()
+	defer listArr.Release()
+
+	lvc := &listValueContainer{
+		listArray:     listArr,
+		listArrayType: arrow.ListOf(elemType),
+		values:        &decimal128Container{scale: scale},
+	}
+	require.NoError(t, lvc.values.SetValueArray(listArr.ListValues().Data()))
+
+	got, err := lvc.Value(0)
+	require.NoError(t, err)
+
+	// Decimals are rendered as lossless JSON strings; NULL stays null (not 0).
+	expected := `["12345678901234567890.123456789012345678",null,"3.300000000000000000"]`
+	assert.Equal(t, expected, got)
+}

--- a/internal/rows/arrowbased/columnValues_test.go
+++ b/internal/rows/arrowbased/columnValues_test.go
@@ -1,0 +1,70 @@
+package arrowbased
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v12/arrow"
+	"github.com/apache/arrow/go/v12/arrow/array"
+	"github.com/apache/arrow/go/v12/arrow/decimal128"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecimal128ContainerValue verifies that the native Arrow decimal path
+// decodes DECIMAL columns losslessly as strings, preserving full precision and
+// scale, and that nulls are surfaced as nil. This is the value-level coverage
+// for the path exercised when UseArrowNativeDecimal is enabled (the boundary
+// test in TestArrowRowScanner only proves ScanRow no longer blocks decimals).
+func TestDecimal128ContainerValue(t *testing.T) {
+	const precision, scale int32 = 38, 18
+
+	// A 38-digit, scale-18 value that float64 (≈15-17 significant digits)
+	// cannot represent exactly — the regression guard for lossy conversion.
+	const highPrecision = "12345678901234567890.123456789012345678"
+
+	// Note: ToString(scale) always renders to the column's full declared scale
+	// (18 here), so values are normalized — e.g. "3.30" -> "3.300000000000000000".
+	// This is lossless and deterministic, unlike a float64 conversion.
+	cases := []struct {
+		name     string
+		input    string // empty string => null
+		expected any
+	}{
+		{name: "high precision preserved", input: highPrecision, expected: highPrecision},
+		{name: "simple value normalized to scale", input: "3.30", expected: "3.300000000000000000"},
+		{name: "negative value", input: "-0.000000000000000001", expected: "-0.000000000000000001"},
+		{name: "zero", input: "0.000000000000000000", expected: "0.000000000000000000"},
+		{name: "null", input: "", expected: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewGoAllocator()
+			dt := &arrow.Decimal128Type{Precision: precision, Scale: scale}
+			b := array.NewDecimal128Builder(mem, dt)
+			defer b.Release()
+
+			if tc.input == "" {
+				b.AppendNull()
+			} else {
+				num, err := decimal128.FromString(tc.input, precision, scale)
+				require.NoError(t, err)
+				b.Append(num)
+			}
+
+			arr := b.NewDecimal128Array()
+			defer arr.Release()
+
+			container := &decimal128Container{scale: scale}
+			err := container.SetValueArray(arr.Data())
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.input == "", container.IsNull(0))
+
+			got, err := container.Value(0)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## What this fixes

The driver has a **live precision bug on the default path**, plus a stranded, unreachable native-decimal code path. This PR fixes both.

**The bug (reachable today, no opt-in required):** complex types are native by default (`UseArrowNativeComplexTypes = true`), so any `DECIMAL` nested inside an `ARRAY`/`STRUCT`/`MAP` is decoded by `decimal128Container`, which used `Decimal128.ToFloat64`. `float64` cannot represent high-precision/high-scale decimals, so values are silently corrupted. Reproduced directly against current `main`:

| Exact value from server | `main` decodes as | |
|---|---|---|
| `12345678901234567890.123456789012345678` | `1.234567890123457e+19` | corrupted |
| `99999999999999999999.999999999999999999` | `1e+20` | collapsed to a round number |
| `3.30` | `3.3000000000000003` | wrong even for a trivial value |
| SQL `NULL` (top-level scan) | `float64(0)` | null becomes a real zero |

**The stranded code:** `UseArrowNativeDecimal` exists as a config field with full wire plumbing (`connection.go` sends `DecimalAsArrow`) and a decode container — but **no DSN key or connector option ever sets it**, so no user can reach the top-level native-decimal path at all. It is dead code.

This is also a corrected take on #282, which tried to enable native decimal by default but kept the lossy `float64` decode (and offered no opt-out). The review of #282 flagged exactly the issues addressed here.

## What this PR does

- **Lossless decode** (`internal/rows/arrowbased/columnValues.go`): `decimal128Container.Value` returns `Decimal128.ToString(scale)` — a scale-normalized, exact string — instead of the lossy `ToFloat64`. It is also null-safe (returns `nil` for null cells, not `0`).
- **Makes the path reachable** (`connector.go`): new public `WithUseArrowNativeDecimal(enable bool) ConnOption`. Previously `ArrowConfig.UseArrowNativeDecimal` lived in `internal/config` with no entry point.
- **Unblocks top-level decimal in `ScanRow`** (`internal/rows/arrowbased/arrowRows.go`): decimals are no longer rejected as "unsupported native type"; interval types remain blocked.
- **Consistent Go type**: returning a string matches both the non-native default path and the column-based (non-Arrow) transport, so a `DECIMAL` column comes back as the same Go type regardless of which transport the server picks. (Previously the native path returned `float64` while the column path returned `string` for the same column.)
- **Default unchanged, non-breaking**: `ArrowConfig.WithDefaults()` still leaves `UseArrowNativeDecimal = false`. For top-level decimal columns the observable Go type is `string` either way; opting in only changes the wire transport. The user-visible behavior fix is for the nested-in-complex-type case, which now decodes losslessly.
- **Docs** (`doc.go`): `DECIMAL(p,s) --> string` (corrects the inaccurate `sql.RawBytes`).
- **CHANGELOG**: entry under `Unreleased`.

## Why string, not a numeric type

`database/sql`'s `driver.Value` has no decimal type — the allowed kinds are `int64`, `float64`, `bool`, `[]byte`, `string`, `time.Time`. Returning `string` is the standard idiom other Go SQL drivers use for `DECIMAL`/`NUMERIC` (e.g. `lib/pq`, `pgx`), because it is exact and lets the caller decode into `shopspring/decimal`, `*big.Rat`, etc. without precision already lost. It is also what this driver already returned for decimals, so it is the non-breaking choice.

## Tests

- **`TestDecimal128ContainerValue`** — asserts exact lossless decode of a `DECIMAL(38,18)` high-precision value, negatives, scale normalization, and `NULL -> nil`. Verified to **fail** against `main`'s `ToFloat64` decode and **pass** with the fix.
- **`TestDecimal128NestedInListPreservesPrecision`** — guards the default path (decimal nested in `ARRAY`). Verified to **fail** against `main` (renders `[12345678901234570000,null,3.3000000000000003]`) and **pass** with the fix.
- Existing `ScanRow` boundary test updated to reflect decimal now succeeding while intervals still error.

`go build ./...`, `go vet ./...`, and `go test ./...` are all clean.

## Behavior change to review deliberately

Nested decimals inside native complex types previously serialized as (lossy) JSON numbers, e.g. `[5.15,123.45,null]`. They now serialize as lossless JSON strings, e.g. `["5.15","123.45",null]`. This is a representation change for direct consumers of native complex-type values, in exchange for exact precision. The relevant existing test expectation is updated accordingly.

## Resolution of the #282 review findings

| Finding on #282 | Resolution here |
|---|---|
| Lossy `float64` (default-path bug) | Lossless `string` via `ToString(scale)` |
| SQL `NULL` decoded as `0` | Null-safe `Value()` returns `nil` |
| No value-level test for the native path | `TestDecimal128ContainerValue` + nested-list test |
| `doc.go` stale (`sql.RawBytes`) | Updated to `string` |
| No public opt-out / path unreachable | `WithUseArrowNativeDecimal` connector option |
| Type confusion (Arrow `float64` vs column `string`) | Both transports return `string` |
| No changelog entry | Added under `Unreleased` |

Refs #282.
