### PR TITLE
Prepare for v1.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## v1.13.0 (2026-06-04)
+- Add SPOG (unified) host support: extract the org-id from the cluster HTTP path for non-Thrift requests, and fix U2M/M2M OAuth on unified AWS hosts (databricks/databricks-sql-go#367, #374)
+- Cap CloudFetch Arrow batches to the server-declared row count to avoid over-reading (databricks/databricks-sql-go#372)
+- Detach result streaming from `QueryContext` cancellation so in-flight results aren't dropped when the query context is cancelled (databricks/databricks-sql-go#373)
+
 ## v1.12.0 (2026-05-25)
 - Retry transient S3 errors in CloudFetch downloads and staging PUT/GET/REMOVE operations (databricks/databricks-sql-go#355, #361)
 - Telemetry: normalize host key for per-host client + breaker registries; stop retrying into 429s, honour Retry-After, fix userAgent (databricks/databricks-sql-go#354, #364)

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.12.0" // update version before each release
+var DriverVersion = "1.13.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.13.0` and add the `v1.13.0` section to `CHANGELOG.md`.

### Notable changes since v1.12.0
- Add SPOG (unified) host support: extract the org-id from the cluster HTTP path for non-Thrift requests, and fix U2M/M2M OAuth on unified AWS hosts (#367, #374)
- Cap CloudFetch Arrow batches to the server-declared row count to avoid over-reading (#372)
- Detach result streaming from `QueryContext` cancellation so in-flight results aren't dropped when the query context is cancelled ([ES-1934053], #373)

## Test plan
- [x] `go test ./... -count=1 -short` passes locally
- [x] Multi-DBR tests in `universe/peco/correctness/go` passed (all 5 suites green on 18.x-photon-scala2.13)
- [ ] CI green

This pull request was AI-assisted by Isaac.

[ES-1934053]: https://databricks.atlassian.net/browse/ES-1934053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ