### PR TITLE
ci: restore pull-requests: write for the PR-comment steps in trigger-integration-tests

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -36,8 +36,10 @@ jobs:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     permissions:
-      # Labels + comments are the issues API; no pulls.* calls here.
+      # removeLabel needs issues:write; commenting on a PR needs pull-requests:write
+      # (GitHub requires the PR scope for issues.createComment on a PR).
       issues: write
+      pull-requests: write
     steps:
       - name: Remove integration-test labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -125,8 +127,11 @@ jobs:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     permissions:
-      # Comments are the issues API; the dispatch uses the App token, not GITHUB_TOKEN.
+      # Commenting on a PR needs pull-requests:write (issues.createComment on a PR
+      # requires the PR scope); checks:write for the failure check. The dispatch
+      # itself uses the App token, not GITHUB_TOKEN.
       issues: write
+      pull-requests: write
       checks: write
     steps:
       - name: Resolve proxy mode from label


### PR DESCRIPTION
Follow-up to the integration-test trigger workflow.

## What
Restores \`pull-requests: write\` on the two jobs that comment on a PR — \`trigger-tests-pr\` and \`remove-label-on-new-commit\`.

## Why
Labeling a PR with \`integration-test\` fired the workflow correctly — the dispatch to \`databricks-driver-test\` succeeded, the replay suite ran, and the \`Go Integration Tests\` check posted back green. But the trailing **Comment on PR** step failed with:

```
HttpError: Resource not accessible by integration (403)
x-accepted-github-permissions: issues=write; pull_requests=write
```

`github.rest.issues.createComment` on a PR is gated behind `pull-requests: write` — a PR comment needs the PR scope, not just `issues: write`. A prior least-privilege change dropped that scope reasoning "comments are the issues API"; that holds for `removeLabel` but not for commenting on a PR. The `databricks-sql-nodejs` and `databricks-sql-python` sibling workflows keep `pull-requests: write` on the equivalent job — this restores parity.

The dispatch itself was never affected (it uses the App token, not `GITHUB_TOKEN`); only the cosmetic comment 403d.
