### PR TITLE
Prepare for v1.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## Unreleased
+## v1.13.1 (2026-07-07)
 - Expose native Arrow decimal handling: add the `WithArrowNativeDecimal` connector option and the `useArrowNativeDecimal` DSN parameter so DECIMAL columns can be returned as native Arrow `decimal128` (via `GetArrowBatches`) instead of strings. When scanned through `database/sql`, native DECIMAL values are returned as lossless, scale-applied strings (databricks/databricks-sql-go#274)
 
 ## v1.13.0 (2026-06-04)

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.13.0" // update version before each release
+var DriverVersion = "1.13.1" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.13.1` and add the `v1.13.1` section to `CHANGELOG.md`.

### Notable changes since v1.13.0
- Expose native Arrow decimal handling: add the `WithArrowNativeDecimal` connector option and the `useArrowNativeDecimal` DSN parameter so DECIMAL columns can be returned as native Arrow `decimal128` (via `GetArrowBatches`) instead of strings. When scanned through `database/sql`, native DECIMAL values are returned as lossless, scale-applied strings (databricks/databricks-sql-go#274)

## Test plan
- [x] `go test ./... -count=1 -short` passes locally
- [x] Multi-DBR tests in `universe/peco/correctness/go` passed (all 5 suites green on `18.x-photon-scala2.13`)
- [ ] CI green

This pull request was AI-assisted by Isaac.