### PR TITLE
Fix panic in InitThriftClient when endpoint URL is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## Unreleased
+- Fix panic in `InitThriftClient` when the endpoint URL is malformed: the thrift transport was type-asserted to `*thrift.THttpClient` before the error from `NewTHttpClientWithOptions` was checked, so a URL that fails to parse (nil transport) caused `interface conversion: thrift.TTransport is nil, not *thrift.THttpClient`; the error is now returned instead (databricks/databricks-sql-go#394)
 - Stop using `html/template` in the U2M OAuth callback page. Reachable use of `html/template` disabled the Go linker's dead-code elimination for the entire binary of any application importing this driver; the page is now rendered with plain string building and explicit HTML escaping, restoring full DCE (databricks/databricks-sql-go#343)
 - Fix DECIMAL precision loss inside complex types: DECIMAL values nested in STRUCT, ARRAY, and MAP columns are now rendered losslessly with their exact scale (e.g. `19.99` instead of `19.990000000000002`), matching the behavior of top-level DECIMAL columns (databricks/databricks-sql-go#253)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -317,15 +317,15 @@ func InitThriftClient(cfg *config.Config, httpclient *http.Client) (*ThriftServi
 		}
 
 		tTrans, err = thrift.NewTHttpClientWithOptions(endpoint, thrift.THttpClientOptions{Client: httpclient})
+		if err != nil {
+			return nil, dbsqlerrint.NewRequestError(context.TODO(), dbsqlerr.ErrInvalidURL, err)
+		}
 
 		thriftHttpClient := tTrans.(*thrift.THttpClient)
 		thriftHttpClient.SetHeader("User-Agent", BuildUserAgent(cfg))
 
 	default:
 		return nil, dbsqlerrint.NewDriverError(context.TODO(), fmt.Sprintf("unsupported transport `%s`", cfg.ThriftTransport), nil)
-	}
-	if err != nil {
-		return nil, dbsqlerrint.NewRequestError(context.TODO(), dbsqlerr.ErrInvalidURL, err)
 	}
 	if err = tTrans.Open(); err != nil {
 		return nil, dbsqlerrint.NewRequestError(context.TODO(), fmt.Sprintf("failed to open http transport for endpoint %s", endpoint), err)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	dbsqlerr "github.com/databricks/databricks-sql-go/errors"
+	"github.com/databricks/databricks-sql-go/internal/config"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -323,5 +324,33 @@ func TestRetryPolicy(t *testing.T) {
 			require.True(t, errors.Is(err, dbsqlerr.RequestError))
 			require.Equal(t, c.isBadConn, errors.Is(err, driver.ErrBadConn))
 		}
+	})
+}
+
+// TestInitThriftClientMalformedEndpointDoesNotPanic is a regression test: when the
+// endpoint URL is malformed, thrift.NewTHttpClientWithOptions returns a nil
+// TTransport and an error. InitThriftClient previously type-asserted that nil
+// transport to *thrift.THttpClient before checking the error, panicking with
+// "interface conversion: thrift.TTransport is nil, not *thrift.THttpClient".
+// It must now surface the error instead.
+func TestInitThriftClientMalformedEndpointDoesNotPanic(t *testing.T) {
+	cfg := &config.Config{
+		UserConfig: config.UserConfig{
+			Protocol: "https",
+			Host:     "example.cloud.databricks.com",
+			Port:     443,
+			// A control character passes ToEndpointURL's non-empty check but
+			// makes url.Parse (inside NewTHttpClientWithOptions) fail.
+			HTTPPath: "/sql/1.0/warehouses/\x7f",
+		},
+		ThriftProtocol:  "binary",
+		ThriftTransport: "http",
+	}
+
+	require.NotPanics(t, func() {
+		// Non-nil httpclient so we exercise the transport path, not the
+		// missing-authenticator early return.
+		_, err := InitThriftClient(cfg, &http.Client{})
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
This surfaces as:

```
interface conversion: thrift.TTransport is nil, not *thrift.THttpClient
```

## Root cause

In `internal/client/client.go`, the HTTP transport path type-asserts the transport **before** checking the error returned by `thrift.NewTHttpClientWithOptions`:

```go
tTrans, err = thrift.NewTHttpClientWithOptions(endpoint, thrift.THttpClientOptions{Client: httpclient})

thriftHttpClient := tTrans.(*thrift.THttpClient)   // panics
...
if err != nil {                                    // never reached on failure
    return nil, dbsqlerrint.NewRequestError(context.TODO(), dbsqlerr.ErrInvalidURL, err)
}
```

`NewTHttpClientWithOptions` returns a nil `TTransport` when `url.Parse(endpoint)` fails (e.g. a host or HTTP path containing a control character or an invalid `%`-escape). Asserting a nil `TTransport` to `*thrift.THttpClient` panics, so the existing `err` check below the `switch` is never reached.

Because the transport is initialized lazily on the first connection (`connector.Connect` → `InitThriftClient`), this surfaces as a crash while acquiring a connection rather than a returned error.

## Fix

Move the error check to immediately after `NewTHttpClientWithOptions`, before the type assertion. The now-unreachable post-`switch` error check is removed; the same `ErrInvalidURL` error is returned as before, without panicking.

## Testing

Added `TestInitThriftClientMalformedEndpointDoesNotPanic`, which builds a config whose HTTP path passes `ToEndpointURL`'s non-empty validation but fails `url.Parse`, and asserts `InitThriftClient` returns an error instead of panicking. Verified the test fails (panics) without the fix and passes with it. `go vet` and `gofmt` are clean and the full `internal/client` package tests pass.