### PR TITLE
Prepare for v1.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
-## Unreleased
+## v1.14.0 (2026-07-13)
+- **Minimum Go version is now 1.25.0** (previously 1.20): the `go` directive was raised to 1.25.0 while clearing OSV-Scanner findings and updating dependencies. Consumers building with an older toolchain will need to upgrade Go (databricks/databricks-sql-go#368)
 - Fix panic in `InitThriftClient` when the endpoint URL is malformed: the thrift transport was type-asserted to `*thrift.THttpClient` before the error from `NewTHttpClientWithOptions` was checked, so a URL that fails to parse (nil transport) caused `interface conversion: thrift.TTransport is nil, not *thrift.THttpClient`; the error is now returned instead (databricks/databricks-sql-go#394)
 - Stop using `html/template` in the U2M OAuth callback page. Reachable use of `html/template` disabled the Go linker's dead-code elimination for the entire binary of any application importing this driver; the page is now rendered with plain string building and explicit HTML escaping, restoring full DCE (databricks/databricks-sql-go#343)
 - Fix DECIMAL precision loss inside complex types: DECIMAL values nested in STRUCT, ARRAY, and MAP columns are now rendered losslessly with their exact scale (e.g. `19.99` instead of `19.990000000000002`), matching the behavior of top-level DECIMAL columns (databricks/databricks-sql-go#253)

--- a/driver.go
+++ b/driver.go
@@ -13,7 +13,7 @@ func init() {
 	sql.Register("databricks", &databricksDriver{})
 }
 
-var DriverVersion = "1.13.1" // update version before each release
+var DriverVersion = "1.14.0" // update version before each release
 
 type databricksDriver struct{}
 


### PR DESCRIPTION
## Summary
Bump `DriverVersion` to `1.14.0` and add the `v1.14.0` section to `CHANGELOG.md`.

### Notable changes since v1.13.1
- **Minimum Go version is now 1.25.0** (previously 1.20): the `go` directive was raised while clearing OSV-Scanner findings and updating dependencies. Consumers building with an older toolchain will need to upgrade Go (#368)
- Fix panic in `InitThriftClient` when the endpoint URL is malformed (#394)
- Stop using `html/template` in the U2M OAuth callback page to restore linker dead-code elimination (fixes #343)
- Fix DECIMAL precision loss inside complex types (STRUCT/ARRAY/MAP) (fixes #253)

## Test plan
- [x] `go test ./... -count=1 -short` passes locally (Go 1.26.4)
- [x] Multi-DBR suites in `universe/peco/correctness/go` passed (5/5 on DBR `18.x-photon-scala2.13`)
- [ ] CI green

This pull request was AI-assisted by Isaac.