### PR TITLE
chore: allowlist Arrow IPC base64 false positives in .gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,40 @@
+# gitleaks finding suppression file (read automatically by `gitleaks
+# detect`, which the Databricks global pre-push hook runs).
+#
+# False positive: these testdata fixtures embed Apache Arrow IPC
+# payloads as base64 ("batch": "/////..."), which are binary result
+# data — NOT credentials. The gitleaks `aws-access-token` rule (which
+# targets AKIA…/ASIA…-style keys) collides with arbitrary high-entropy
+# base64 substrings inside the Arrow chunk (entropy ~1.5 vs ~4.3+ for a
+# real AWS key).
+#
+# `gitleaks detect` fingerprints are commit-SHA-prefixed. All of these
+# were introduced by commit f27a47b ("Fetch results in arrow format",
+# #109), so they re-surface whenever a new branch's scan range walks
+# back through history and re-includes that commit — even for commits
+# that never touch these files.
+
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/all_types.json:aws-access-token:291
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/all_types_arrow_schema.json:aws-access-token:299
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/all_types_native_complex.json:aws-access-token:280
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/all_types_time_strings.json:aws-access-token:291
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/all_types_with_schema_native.json:aws-access-token:280
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/arrays_native.json:aws-access-token:242
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:197
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:201
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:209
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:213
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:225
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:253
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:265
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:277
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:285
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:293
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:317
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:329
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:345
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:369
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:373
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:389
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/diamonds.json:aws-access-token:409
+f27a47bb8e2208f6963393bbe4504b6e2b600648:internal/rows/arrowbased/testdata/structs_native.json:aws-access-token:61


### PR DESCRIPTION
## Problem

The Databricks global pre-push secret scanner runs `gitleaks detect` over each new branch's commit range. The `aws-access-token` rule (which targets `AKIA…`/`ASIA…`-style keys) collides with high-entropy base64 substrings inside the **Apache Arrow IPC payloads** stored in the `internal/rows/arrowbased/testdata` fixtures (`"batch": "/////5gCAAAU…"`).

This produces **24 false positives across 8 fixture files** (`diamonds.json`, `all_types*.json`, `arrays_native.json`, `structs_native.json`). They are binary Arrow result data, not credentials — entropy ~1.5 vs ~4.3+ for a real AWS key.

All were introduced by `f27a47b` ("Fetch results in arrow format", #109). Because `gitleaks detect` fingerprints are commit-SHA-prefixed and the scan walks back through history, these re-surface on **every new branch** — even branches that never touch these files — forcing contributors to push with `SKIP_SECRET_SCAN=1`.

## Fix

Commit a repo-root `.gitleaksignore` listing the 24 SHA-prefixed fingerprints. `gitleaks detect` reads this file automatically, so the false positives are suppressed permanently for all branches with no per-push workaround. This mirrors the approach already used in `databricks-driver-test`.

## Verification

Re-running the exact pre-push scan against the introducing commit with the file present:

```
gitleaks detect -c gitleaks.toml --exit-code 3 --log-opts="-p -1 f27a47b…"
→ no leaks found (exit 0)
```

The push of this branch itself passed the pre-push secret scan with no block.

This pull request and its description were written by Isaac.