### PR TITLE
Add ErrorCategory type and constants for telemetry error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Unreleased
+- Add an internal `ErrorCategory` type and category constants in `internal/errors` as the first step of enriching telemetry error classification (PECOBLR-3537). No behavior change yet: the type is not read or attached anywhere in this change (databricks/databricks-sql-go#XXXX)
+
 ## v1.14.0 (2026-07-13)
 - **Minimum Go version is now 1.25.0** (previously 1.20): the `go` directive was raised to 1.25.0 while clearing OSV-Scanner findings and updating dependencies. Consumers building with an older toolchain will need to upgrade Go (databricks/databricks-sql-go#368)
 - Fix panic in `InitThriftClient` when the endpoint URL is malformed: the thrift transport was type-asserted to `*thrift.THttpClient` before the error from `NewTHttpClientWithOptions` was checked, so a URL that fails to parse (nil transport) caused `interface conversion: thrift.TTransport is nil, not *thrift.THttpClient`; the error is now returned instead (databricks/databricks-sql-go#394)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## Unreleased
-- Add an internal `ErrorCategory` type and category constants in `internal/errors` as the first step of enriching telemetry error classification (PECOBLR-3537). No behavior change yet: the type is not read or attached anywhere in this change (databricks/databricks-sql-go#XXXX)
+- Add an internal `ErrorCategory` type and category constants in `internal/errors` for telemetry error classification. No behavior change: the type is not read or attached anywhere yet (databricks/databricks-sql-go#414)
 
 ## v1.14.0 (2026-07-13)
 - **Minimum Go version is now 1.25.0** (previously 1.20): the `go` directive was raised to 1.25.0 while clearing OSV-Scanner findings and updating dependencies. Consumers building with an older toolchain will need to upgrade Go (databricks/databricks-sql-go#368)

--- a/internal/errors/category.go
+++ b/internal/errors/category.go
@@ -1,0 +1,30 @@
+package errors
+
+// ErrorCategory is a source-declared classification for a driver error, so
+// telemetry can read the category directly instead of inferring it from the
+// error message.
+type ErrorCategory string
+
+const (
+	CategoryTimeout              ErrorCategory = "timeout"
+	CategoryCancelled            ErrorCategory = "cancelled"
+	CategoryConnectionError      ErrorCategory = "connection_error"
+	CategoryAuthError            ErrorCategory = "auth_error"
+	CategoryPermissionError      ErrorCategory = "permission_error"
+	CategoryNotFound             ErrorCategory = "not_found"
+	CategorySyntaxError          ErrorCategory = "syntax_error"
+	CategoryInvalidRequest       ErrorCategory = "invalid_request"
+	CategoryGeneric              ErrorCategory = "error"
+	CategoryChunkDownload        ErrorCategory = "chunk_download_error"
+	CategoryDecompression        ErrorCategory = "decompression_error"
+	CategoryArrowSchemaParsing   ErrorCategory = "arrow_schema_parsing_error"
+	CategoryResultSet            ErrorCategory = "result_set_error"
+	CategoryUnsupportedOperation ErrorCategory = "unsupported_operation"
+	CategoryRateLimitExceeded    ErrorCategory = "rate_limit_exceeded"
+	CategorySSLHandshake         ErrorCategory = "ssl_handshake_error"
+	CategoryStatementTimeout     ErrorCategory = "statement_execution_timeout"
+	CategoryExecuteStatement     ErrorCategory = "execute_statement_failed"
+	CategoryStatementCancelled   ErrorCategory = "execute_statement_cancelled"
+	CategorySessionClosed        ErrorCategory = "session_closed"
+	CategoryStatementClosed      ErrorCategory = "statement_closed"
+)


### PR DESCRIPTION
## What
Adds an internal `ErrorCategory` string type in `internal/errors` with the
category constants used to classify driver errors for telemetry:

## Why
`classifyError` currently infers a category by substring-matching the error
*message* which is fragile and lossy. The goal is to declare the category at the error
source and have `classifyError` read it directly. This PR adds only the
category type and constants.

Design doc: https://docs.google.com/document/d/12ufP1eZrgFxWt6xzINfkhfrE-NnhB29zCa5PKokVfp8/edit
Jira: PECOBLR-3537