### PR TITLE
docs: correct kernel proxy (SOCKS) and session-conf allowlist caveats

### DIFF
--- a/CONNECTION_PARAMETERS.md
+++ b/CONNECTION_PARAMETERS.md
@@ -15,7 +15,7 @@ sections of the README, laid out as one comparison matrix per concern.
 |:---:|---|
 | ✅ | Supported and honored. |
 | ❌ | Not supported — **rejected** at connect/execute (wraps `dbsqlerr.ErrNotSupportedByKernel` or `dbsqlerr.ErrRequiresKernelBackend`), never silently ignored. |
-| ⚠️ | Accepted but has no effect ("inert" / silently ignored). |
+| ⚠️ | Accepted but not fully honored — either inert ("silently ignored") or only partially/conditionally honored (e.g. some session confs are honored while others are dropped/rejected on the kernel path). |
 | — | Not applicable. |
 
 **Backend selection.** Both backends are selected once per connection via

--- a/CONNECTION_PARAMETERS.md
+++ b/CONNECTION_PARAMETERS.md
@@ -25,7 +25,11 @@ sections of the README, laid out as one comparison matrix per concern.
 See [Building](./README.md#building).
 
 Any parameter not listed below (e.g. `ansi_mode`) is passed through as a
-**session parameter** on both backends.
+**session parameter**. On the **Thrift** path the session-conf map is forwarded freely.
+On the **kernel** path conf keys are matched (case-insensitively) against an allowlist —
+non-allowlisted keys are dropped with a warning, and a few are hard-rejected — so a conf
+that takes effect on Thrift may silently be ignored on kernel. Broadening the kernel
+allowlist is tracked in PECOBLR-4153.
 
 ## Endpoint & routing
 
@@ -65,7 +69,7 @@ Notes for the SEA/kernel backend:
 | `maxRows` | `WithMaxRows` | ✅ | ⚠️ | `100000` | Max rows per fetch. On the kernel path the kernel manages paging, so this is accepted but has no effect. |
 | `timeout` | `WithTimeout` | ✅ | ❌ | no timeout | Server-side query timeout, in seconds. On the kernel path use the `STATEMENT_TIMEOUT` session parameter instead. |
 | `userAgentEntry` | `WithUserAgentEntry` | ✅ | ✅ | | Identifies your application (partners/ISVs), format `<isv-name+product-name>`. |
-| *(session param)* | `WithSessionParams` | ✅ | ✅ | | Arbitrary session confs (e.g. `ansi_mode`, `STATEMENT_TIMEOUT`, `QUERY_TAGS`). |
+| *(session param)* | `WithSessionParams` | ✅ | ⚠️ | | Arbitrary session confs (e.g. `ansi_mode`, `STATEMENT_TIMEOUT`, `QUERY_TAGS`). Allowlisted confs are honored on both; on kernel a non-allowlisted conf is dropped/rejected (see the note above; PECOBLR-4153). |
 | *(via session param)* | `WithQueryTags` | ✅ | ✅ | | Session-level query tags (serialized into `QUERY_TAGS`). |
 | `timezone` | `WithSessionParams(timezone=…)` | ✅ | ✅ | | Session time zone (e.g. `America/Los_Angeles`). |
 | `enableMetricViewMetadata` | `WithEnableMetricViewMetadata` | ✅ | ✅ | `false` | Enables metric-view metadata (`spark.sql.thriftserver.metadata.metricview.enabled=true`). |
@@ -109,7 +113,9 @@ BINARY as `sql.RawBytes`).
 ## Proxy
 
 Both backends honor the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` environment
-variables.
+variables. Note the kernel path accepts **http(s) proxies only**: a `socks*` proxy URL
+(honored on the Thrift path) is rejected at connect on the kernel path. Kernel SOCKS
+support is tracked in PECOBLR-4152.
 
 | Connector option | Thrift | Kernel | Notes |
 |---|:---:|:---:|---|

--- a/CONNECTION_PARAMETERS.md
+++ b/CONNECTION_PARAMETERS.md
@@ -72,7 +72,7 @@ Notes for the SEA/kernel backend:
 | *(session param)* | `WithSessionParams` | ✅ | ⚠️ | | Arbitrary session confs (e.g. `ansi_mode`, `STATEMENT_TIMEOUT`, `QUERY_TAGS`). Allowlisted confs are honored on both; on kernel a non-allowlisted conf is dropped/rejected (see the note above; PECOBLR-4153). |
 | *(via session param)* | `WithQueryTags` | ✅ | ✅ | | Session-level query tags (serialized into `QUERY_TAGS`). |
 | `timezone` | `WithSessionParams(timezone=…)` | ✅ | ✅ | | Session time zone (e.g. `America/Los_Angeles`). |
-| `enableMetricViewMetadata` | `WithEnableMetricViewMetadata` | ✅ | ✅ | `false` | Enables metric-view metadata (`spark.sql.thriftserver.metadata.metricview.enabled=true`). |
+| `enableMetricViewMetadata` | `WithEnableMetricViewMetadata` | ✅ | ⚠️ | `false` | Enables metric-view metadata (sets `spark.sql.thriftserver.metadata.metricview.enabled=true`). The driver forwards the conf on both paths, but the kernel currently hard-rejects it (HTTP 400 `INVALID_CONF_VALUE`), so it does not yet take effect on the kernel path (PECOBLR-4142 / PECOBLR-4153). |
 
 ## Retry / backoff
 


### PR DESCRIPTION
## What

Follow-up to #445. Three behaviors were overstated for the kernel path in `CONNECTION_PARAMETERS.md`; this corrects them.

1. **Session parameters.** The blanket "passed through as a session parameter on both backends" claim is inaccurate for the kernel path: the kernel matches conf keys (case-insensitively) against an allowlist, dropping non-allowlisted keys with a warning and hard-rejecting a few. Thrift forwards the conf map freely. Updated the passthrough note to spell out the Thrift-vs-kernel difference and changed the `WithSessionParams` Kernel cell from ✅ to ⚠️. Tracked in PECOBLR-4153.
2. **Proxy.** The kernel path accepts **http(s) proxies only** — a `socks*` proxy URL that the Thrift path honors is rejected at connect on the kernel path. Added that caveat to the Proxy section. Tracked in PECOBLR-4152.
3. **enableMetricViewMetadata.** The driver folds `spark.sql.thriftserver.metadata.metricview.enabled=true` into `SessionConf` on both paths (`kernel_config.go`), but the kernel currently hard-rejects that conf (HTTP 400 `INVALID_CONF_VALUE`), so it does not take effect on the kernel path today. Flipped the Kernel cell ✅ → ⚠️ with a caveat. Fix tracked in PECOBLR-4142 / PECOBLR-4153.

All three surfaced while cross-referencing the doc against the kernel-parity Jira items under PECOBLR-3727.

## Note

Opened as a new PR because #445 was already merged and its branch deleted, so a follow-up commit to that PR wasn't possible.

This pull request and its description were written by Isaac.