### PR TITLE
fix: keep the module root a single package (tools.go -> go.mod tool directive)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,14 @@ module github.com/databricks/databricks-sql-go
 
 go 1.25.0
 
+// gotestsum is a build-time test runner (see the Makefile's test/coverage
+// targets), not a library the driver imports. The tool directive (Go 1.24+)
+// keeps it in the module graph — the job the old //go:build tools file did —
+// without declaring a second package in the module root.
+//
+// See https://github.com/databricks/databricks-sql-go/issues/162.
+tool gotest.tools/gotestsum
+
 require (
 	github.com/apache/arrow/go/v12 v12.0.1
 	github.com/apache/thrift v0.23.0
@@ -12,7 +20,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.15
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.27.0
-	gotest.tools/gotestsum v1.8.2
 )
 
 require (
@@ -43,6 +50,7 @@ require (
 	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/gotestsum v1.8.2 // indirect
 )
 
 require (

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,0 @@
-//go:build tools
-
-package tools
-
-import (
-	_ "gotest.tools/gotestsum"
-)

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,30 @@
+package dbsql
+
+import (
+	"go/build"
+	"testing"
+)
+
+// TestModuleRootIsASinglePackage guards the fix for #162: the module root must
+// declare exactly one package no matter which build tags are in play.
+//
+// The build-time test runner used to be pinned by a `//go:build tools` file
+// declaring `package tools` next to `package dbsql`. Tooling that resolves a
+// directory's package without honoring build constraints (bazel/gazelle) — or
+// that deliberately enables the `tools` tag (golangci-lint) — then saw two
+// package names in one directory and failed to load the driver. gotestsum is
+// pinned by the go.mod `tool` directive instead, so nothing but `dbsql` lives
+// here.
+func TestModuleRootIsASinglePackage(t *testing.T) {
+	ctx := build.Default
+	// Any tag a consumer might enable must not conjure a second package; "tools"
+	// is the one that historically did.
+	ctx.BuildTags = append(ctx.BuildTags, "tools")
+
+	if _, err := ctx.ImportDir(".", 0); err != nil {
+		if _, multiple := err.(*build.MultiplePackageError); multiple {
+			t.Fatalf("module root declares more than one package: %v", err)
+		}
+		t.Fatalf("could not load the module root: %v", err)
+	}
+}


### PR DESCRIPTION
## Context

close #162

`tools.go` pinned the `gotestsum` test runner with the pre-Go-1.24 "tools.go" idiom: a `//go:build tools` file declaring `package tools` in the module root, next to `package dbsql`. Two package names in one directory is only invisible to tools that honor build constraints, and two independent reports say downstream tooling does not:

- bazel/gazelle largely ignores build tags when it first resolves a directory's package, so vendoring the driver fails (the original report);
- `golangci-lint` on a project that uses a `tools` build tag internally hits a compile error on the driver's root package (https://github.com/databricks/databricks-sql-go/issues/162#issuecomment-3835874952).

Reproducible from a clean checkout of `main`:

```console
$ go list -tags tools .
found packages dbsql (category_test.go) and tools (tools.go) in /path/to/databricks-sql-go
```

## What

- Delete `tools.go` and pin the runner with the go.mod `tool` directive (Go 1.24+) instead. The module already declares `go 1.25.0`, so the directive is available.
- Keep `gotestsum` at **v1.8.2** — this is a mechanism change, not a version bump, so it does not overlap with #334.
- Add `tools_test.go`, a tripwire that loads the module root through `go/build` with the `tools` tag enabled and fails if the directory ever declares more than one package again. Verified it fails when `tools.go` is restored:
  ```
  --- FAIL: TestModuleRootIsASinglePackage (0.00s)
      tools_test.go:26: module root declares more than one package: found packages dbsql (category_test.go) and tools (tools.go) in .
  ```

No Makefile or CI change is needed: `tool` keeps the module in the build list, so the `bin/gotestsum` target's `go build -o bin/gotestsum gotest.tools/gotestsum` resolves exactly as before.

The only go.mod churn beyond the directive is `go mod tidy` moving the `gotest.tools/gotestsum` require line into the indirect block — that is what Go itself emits for a tool-only dependency (`go get -tool` on a scratch module produces the same annotation), since no package in the main module imports it.

## Why

The `tool` directive is the supported replacement for the tools.go idiom and expresses the intent directly ("build-time tool", not "library the driver imports"), so the placeholder package that broke consumers is simply gone rather than renamed or relocated.

One honest caveat: `go build -tags tools ./...` still reports collisions, but they now come only from `apache/arrow/go/v12`, which ships its own `tools.go` (`found packages arrow (array.go) and tools (tools.go)` under the module cache). That is upstream and outside this repo's control; this change removes the one collision this module owns, which is the one both reporters hit on the driver's root package.

## Completion Criteria

- [x] `go list -tags tools .` succeeds (previously failed with the two-package error)
- [x] `go mod tidy` is a no-op on the committed go.mod
- [x] `make test` — 1097 tests pass, 2 e2e self-skipped (no warehouse credentials)
- [x] `make test-race` passes
- [x] `./bin/golangci-lint run` (v2.12.2, as CI pins) — 0 issues
- [x] `make tools` still builds `bin/gotestsum` from the pinned v1.8.2
- [x] New test fails if `tools.go` comes back
- [x] Commit signed off (DCO)
