### PR TITLE
feat(kernel): add max connections option

### DIFF
--- a/CONNECTION_PARAMETERS.md
+++ b/CONNECTION_PARAMETERS.md
@@ -110,12 +110,13 @@ Notes:
   creation and stripped before the SEA wire. The driver
   exposes the relevant ones as dedicated `WithKernel*` options rather than raw confs.
 
-## Retry / backoff
+## HTTP client / retry
 
 | Connector option | Thrift | Kernel | Default | Notes |
 |---|:---:|:---:|---|---|
 | `WithRetries(retryMax, waitMin, waitMax)` | ✅ | ✅ | `4`, `1s`, `30s` | Retry attempts and exponential-backoff bounds. `retryMax < 0` disables retries. |
 | `WithKernelRetryOverallTimeout(d)` | ❌ | ✅ | kernel default (900s) | Cumulative retry budget across all attempts. No Thrift equivalent. |
+| `WithKernelMaxConnections(n)` | ❌ | ✅ | kernel default (100) | Maximum idle HTTP connections retained per host, not a hard concurrency cap. `n` must be positive. |
 
 ## Result rendering
 

--- a/connector.go
+++ b/connector.go
@@ -751,6 +751,18 @@ func WithKernelRetryOverallTimeout(d time.Duration) ConnOption {
 	}
 }
 
+// WithKernelMaxConnections sets the maximum number of idle HTTP connections
+// retained per host by the kernel. The default is 100.
+//
+// EXPERIMENTAL, kernel-only: n must be positive, and the default (Thrift)
+// backend rejects this option at connect.
+func WithKernelMaxConnections(n int) ConnOption {
+	return func(c *config.Config) {
+		max := n
+		kernelExperimental(c).MaxConnections = &max
+	}
+}
+
 // WithKernelMaxChunksInMemory bounds how many decompressed CloudFetch chunks the
 // kernel holds in memory at once on the kernel backend — the knob that trades
 // large-result throughput for peak RSS. Lower it (e.g. 4) to cap memory on wide,

--- a/doc.go
+++ b/doc.go
@@ -267,6 +267,8 @@ WithKernel* prefix marks them experimental):
     is kernel-only because the Thrift WithRetries surface has no overall-budget
     equivalent; it mirrors the pyo3/napi retry_overall_timeout knob. Zero keeps the
     kernel's default budget (900s).
+  - WithKernelMaxConnections(n) sets the maximum number of idle HTTP connections
+    retained per host. The default is 100; n must be positive.
   - WithKernelMaxChunksInMemory(n) bounds how many decompressed CloudFetch chunks the
     kernel holds in memory at once — the knob that trades large-result download
     throughput for peak RSS. Lower it (e.g. 4) to cap memory on wide, row-heavy result

--- a/internal/backend/kernel/backend.go
+++ b/internal/backend/kernel/backend.go
@@ -23,6 +23,11 @@ static inline KernelStatusCode go_kernel_set_retry_config(
       config, min_wait_ms, max_wait_ms, max_retries, overall_timeout_ms);
 }
 
+static inline KernelStatusCode go_kernel_set_max_connections(
+    KernelSessionConfig* config, size_t max_connections) {
+  return kernel_session_config_set_max_connections(config, max_connections);
+}
+
 static inline KernelStatusCode go_kernel_set_telemetry_config(
     KernelSessionConfig* config, bool enabled, size_t batch_size,
     uint64_t flush_interval_ms, uint32_t max_retries, uint64_t retry_delay_ms,
@@ -243,6 +248,9 @@ func (k *KernelBackend) OpenSession(ctx context.Context) error {
 	if err := k.applyRequestTimeout(cfg); err != nil {
 		return err
 	}
+	if err := k.applyMaxConnections(cfg); err != nil {
+		return err
+	}
 
 	// Retry / backoff policy (WithRetries). See applyRetry.
 	if err := k.applyRetry(cfg); err != nil {
@@ -399,6 +407,18 @@ func (k *KernelBackend) applyRequestTimeout(cfg *C.KernelSessionConfig) error {
 		return C.kernel_session_config_set_request_timeout(cfg, C.uint64_t(timeoutMs))
 	}); err != nil {
 		return fmt.Errorf("kernel: set_request_timeout: %w", toConnError(err))
+	}
+	return nil
+}
+
+func (k *KernelBackend) applyMaxConnections(cfg *C.KernelSessionConfig) error {
+	if k.cfg.MaxConnections == 0 {
+		return nil
+	}
+	if err := call(func() C.KernelStatusCode {
+		return C.go_kernel_set_max_connections(cfg, C.size_t(k.cfg.MaxConnections))
+	}); err != nil {
+		return fmt.Errorf("kernel: set_max_connections: %w", toConnError(err))
 	}
 	return nil
 }
@@ -692,6 +712,18 @@ func trySetRequestTimeout(cfg Config) error {
 	defer C.kernel_session_config_free(c)
 	k := &KernelBackend{cfg: cfg}
 	return k.applyRequestTimeout(c)
+}
+
+// trySetMaxConnections exercises the max-connections C setter without opening
+// a network session. It is used only by the tagged kernel tests.
+func trySetMaxConnections(cfg Config) error {
+	var c *C.KernelSessionConfig
+	if err := call(func() C.KernelStatusCode { return C.kernel_session_config_new(&c) }); err != nil {
+		return fmt.Errorf("config_new: %w", err)
+	}
+	defer C.kernel_session_config_free(c)
+	k := &KernelBackend{cfg: cfg}
+	return k.applyMaxConnections(c)
 }
 
 // trySetTelemetry exercises the telemetry C setter without opening a network

--- a/internal/backend/kernel/config.go
+++ b/internal/backend/kernel/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	// neither unlimited nor an immediate timeout.
 	RequestTimeout time.Duration
 
+	// MaxConnections is the maximum number of idle HTTP connections retained
+	// per host. Zero keeps the kernel default (100).
+	MaxConnections int
+
 	// SessionConf carries server-bound session confs verbatim — the same map the
 	// Thrift backend forwards (STATEMENT_TIMEOUT, QUERY_TAGS, TIMEZONE, …).
 	SessionConf map[string]string

--- a/internal/backend/kernel/kernel_test.go
+++ b/internal/backend/kernel/kernel_test.go
@@ -187,6 +187,22 @@ func TestSetRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestSetMaxConnections(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		max  int
+	}{
+		{"configured", 37},
+		{"unset is no-op", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := trySetMaxConnections(Config{MaxConnections: tc.max}); err != nil {
+				t.Errorf("applyMaxConnections(%s) = %v, want nil", tc.name, err)
+			}
+		})
+	}
+}
+
 func TestSetTelemetry(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,10 @@ type KernelExperimentalConfig struct {
 	// retry_overall_timeout knob).
 	RetryOverallTimeout time.Duration
 
+	// MaxConnections is the maximum number of idle HTTP connections retained per
+	// host by the kernel. Nil keeps the kernel default (100).
+	MaxConnections *int
+
 	// MaxChunksInMemory bounds how many decompressed CloudFetch chunks the kernel
 	// holds in memory at once (WithKernelMaxChunksInMemory) — the knob that trades
 	// throughput for peak RSS on large result sets. Zero = keep the kernel default
@@ -147,6 +151,10 @@ func (k *KernelExperimentalConfig) DeepCopy() *KernelExperimentalConfig {
 		MaxChunksInMemory:       k.MaxChunksInMemory,
 		DecimalAsFloat:          k.DecimalAsFloat,
 		TokenCacheEnabled:       k.TokenCacheEnabled,
+	}
+	if k.MaxConnections != nil {
+		max := *k.MaxConnections
+		cp.MaxConnections = &max
 	}
 	if k.TLSTrustedCertsPEM != nil {
 		cp.TLSTrustedCertsPEM = append([]byte(nil), k.TLSTrustedCertsPEM...)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -804,6 +804,7 @@ func TestConfig_DeepCopy(t *testing.T) {
 		}
 	})
 	t.Run("copy config with all values", func(t *testing.T) {
+		maxConnections := 37
 		cfg := &Config{
 			UserConfig:                UserConfig{}.WithDefaults(),
 			TLSConfig:                 &tls.Config{MinVersion: tls.VersionTLS12},
@@ -823,6 +824,7 @@ func TestConfig_DeepCopy(t *testing.T) {
 				TLSClientKeyPEM:         []byte("client-key"),
 				TLSClientCertConfigured: true,
 				TLSSkipHostnameVerify:   true,
+				MaxConnections:          &maxConnections,
 			},
 		}
 
@@ -833,6 +835,9 @@ func TestConfig_DeepCopy(t *testing.T) {
 		// The experimental block must be deep-copied, not aliased.
 		if cfg_copy.KernelExperimental == cfg.KernelExperimental {
 			t.Error("DeepCopy aliased KernelExperimental pointer")
+		}
+		if cfg_copy.KernelExperimental.MaxConnections == cfg.KernelExperimental.MaxConnections {
+			t.Error("DeepCopy aliased KernelExperimental MaxConnections pointer")
 		}
 		cfg_copy.KernelExperimental.TLSTrustedCertsPEM[0] = 'X'
 		if cfg.KernelExperimental.TLSTrustedCertsPEM[0] == 'X' {

--- a/kernel_config.go
+++ b/kernel_config.go
@@ -122,6 +122,12 @@ func validateKernelConfigContext(ctx context.Context, cfg *config.Config) (kerne
 			)
 		}
 	}
+	if ke := cfg.KernelExperimental; ke != nil && ke.MaxConnections != nil && *ke.MaxConnections <= 0 {
+		return kernel.Auth{}, fmt.Errorf(
+			"databricks: WithKernelMaxConnections requires a positive value: %w",
+			dbsqlerr.ErrInvalidKernelConfig,
+		)
+	}
 	return kauth, nil
 }
 
@@ -171,6 +177,9 @@ func buildKernelConfig(cfg *config.Config, kauth kernel.Auth) kernel.Config {
 		kc.TLSClientCertPEM = ke.TLSClientCertPEM
 		kc.TLSClientKeyPEM = ke.TLSClientKeyPEM
 		kc.TLSSkipHostnameVerify = ke.TLSSkipHostnameVerify
+		if ke.MaxConnections != nil {
+			kc.MaxConnections = *ke.MaxConnections
+		}
 		// Kernel-only CloudFetch in-memory-chunk knob (WithKernelMaxChunksInMemory).
 		// Injected into the kernel backend's own SessionConf ONLY (not via
 		// EffectiveSessionParams, which both backends share) as the client-only key

--- a/kernel_config_test.go
+++ b/kernel_config_test.go
@@ -369,6 +369,17 @@ func TestValidateKernelConfig(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("non-positive WithKernelMaxConnections rejected as ErrInvalidKernelConfig", func(t *testing.T) {
+		for _, value := range []int{0, -1} {
+			c := baseKernelConfig()
+			WithKernelMaxConnections(value)(c)
+			_, err := validateKernelConfig(c)
+			if !errors.Is(err, dbsqlerr.ErrInvalidKernelConfig) {
+				t.Errorf("WithKernelMaxConnections(%d) should be ErrInvalidKernelConfig, got %v", value, err)
+			}
+		}
+	})
 }
 
 // kernelConfigFieldDisposition records, for every UserConfig field, how the kernel
@@ -483,6 +494,15 @@ func TestKernelConfigFieldsClassified(t *testing.T) {
 // TestKernelExperimentalFieldsClassified only asserts the disposition map, not the
 // runtime copy). These run in the default CGO_ENABLED=0 build.
 func TestBuildKernelConfig(t *testing.T) {
+	t.Run("max connections forwarded", func(t *testing.T) {
+		c := baseKernelConfig()
+		WithKernelMaxConnections(37)(c)
+		kc := buildKernelConfig(c, kernel.Auth{Mode: kernel.AuthPAT, Token: "dapi-x"})
+		if kc.MaxConnections != 37 {
+			t.Errorf("MaxConnections = %d, want 37", kc.MaxConnections)
+		}
+	})
+
 	t.Run("experimental TLS fields forwarded", func(t *testing.T) {
 		c := baseKernelConfig()
 		c.KernelExperimental = &config.KernelExperimentalConfig{

--- a/kernel_experimental_test.go
+++ b/kernel_experimental_test.go
@@ -37,6 +37,7 @@ var kernelExperimentalFieldDisposition = map[string]string{
 	"ProxyPassword":           "forwarded", // set_proxy (password)
 	"ProxyBypassHosts":        "forwarded", // set_proxy (bypass_hosts)
 	"RetryOverallTimeout":     "forwarded", // set_retry_config (overall_timeout_ms, 4th knob)
+	"MaxConnections":          "forwarded", // set_max_connections
 	"MaxChunksInMemory":       "forwarded", // set_session_conf (cloudfetch_max_chunks_in_memory, client-only)
 	"DecimalAsFloat":          "forwarded", // kernel.Config.DecimalAsFloat → kernelOp → arrowscan (client-side scan choice)
 	"TokenCacheEnabled":       "forwarded", // set_u2m_token_cache_config (enabled, nil passphrase)
@@ -90,6 +91,9 @@ func TestWithKernelTLSOptionsSetExperimental(t *testing.T) {
 		{"retry overall timeout", WithKernelRetryOverallTimeout(5 * time.Minute), func(k *config.KernelExperimentalConfig) bool {
 			return k.RetryOverallTimeout == 5*time.Minute
 		}},
+		{"max connections", WithKernelMaxConnections(37), func(k *config.KernelExperimentalConfig) bool {
+			return k.MaxConnections != nil && *k.MaxConnections == 37
+		}},
 		{"max chunks in memory", WithKernelMaxChunksInMemory(4), func(k *config.KernelExperimentalConfig) bool {
 			return k.MaxChunksInMemory == 4
 		}},
@@ -131,6 +135,7 @@ func TestWithKernelOptionsRejectedOnThriftPath(t *testing.T) {
 		{"skip hostname", WithKernelSkipHostnameVerify()},
 		{"proxy", WithKernelProxy(KernelProxy{URL: "http://proxy:3128"})},
 		{"retry overall timeout", WithKernelRetryOverallTimeout(5 * time.Minute)},
+		{"max connections", WithKernelMaxConnections(37)},
 		{"max chunks in memory", WithKernelMaxChunksInMemory(4)},
 		{"decimal as float", WithKernelDecimalAsFloat(true)},
 		{"token cache", WithTokenCache(true)},
@@ -212,6 +217,7 @@ func TestWithKernelClientCertificateCopiesPEM(t *testing.T) {
 // the whole Config per conn, and a shared backing array would let one conn's
 // mutation reach another.
 func TestKernelExperimentalDeepCopy(t *testing.T) {
+	maxConnections := 37
 	orig := &config.KernelExperimentalConfig{
 		TLSTrustedCertsPEM:      []byte("ca-bundle"),
 		TLSClientCertPEM:        []byte("client-cert"),
@@ -223,6 +229,7 @@ func TestKernelExperimentalDeepCopy(t *testing.T) {
 		ProxyPassword:           "p",
 		ProxyBypassHosts:        "*.internal",
 		RetryOverallTimeout:     5 * time.Minute,
+		MaxConnections:          &maxConnections,
 		MaxChunksInMemory:       4,
 		TokenCacheEnabled:       true,
 	}
@@ -236,6 +243,11 @@ func TestKernelExperimentalDeepCopy(t *testing.T) {
 	}
 	if cp.RetryOverallTimeout != 5*time.Minute {
 		t.Errorf("DeepCopy lost RetryOverallTimeout: %v", cp.RetryOverallTimeout)
+	}
+	if cp.MaxConnections == nil || *cp.MaxConnections != 37 {
+		t.Errorf("DeepCopy lost MaxConnections: %v", cp.MaxConnections)
+	} else if cp.MaxConnections == orig.MaxConnections {
+		t.Error("DeepCopy aliased MaxConnections pointer")
 	}
 	if cp.MaxChunksInMemory != 4 {
 		t.Errorf("DeepCopy lost MaxChunksInMemory: %v", cp.MaxChunksInMemory)


### PR DESCRIPTION
Add experimental `WithKernelMaxConnections(n)` and forward it through `kernel_session_config_set_max_connections`. Positive values set the maximum idle HTTP connections retained per host; omission keeps the kernel default of 100.

This mirrors Node's private `maxConnections` option and Python's `_pool_maxsize` forwarding. Kernel support landed in databricks/databricks-sql-kernel#311; the matching kernel revision and C header landed in #469.

Published bindings remain at v1.0.0; bump the kernel bindings modules to v1.1.0 before the next driver release.

Tests: `make test-kernel`.