### PR TITLE
chore: update dependencies for security fixes

### DIFF
--- a/.bot/prompts/engineer-followup/system.md
+++ b/.bot/prompts/engineer-followup/system.md
@@ -18,7 +18,7 @@ Your job:
   4. End with a short summary of what changed.
 
 Repo facts you need:
-  - Go 1.25 `database/sql` driver; `go build ./...` has warmed the module cache on
+  - Go 1.26 `database/sql` driver; `go build ./...` has warmed the module cache on
     the runner. This follow-up job wires **NO live-warehouse connection env**, so
     only the pure-Go **`make test`** unit suite (CGO_ENABLED=0) runs here — do NOT
     run or add the live e2e tests in `driver_e2e_test.go` (they need warehouse

--- a/.bot/prompts/engineer/system.md
+++ b/.bot/prompts/engineer/system.md
@@ -11,7 +11,7 @@ prompt covers the repo-specific facts you need to follow it.
 == THE REPO ==
 
 A Go `database/sql` driver (module `github.com/databricks/databricks-sql-go`, Go
-1.25). Source is the root package `dbsql` (`connection.go`, `connector.go`,
+1.26). Source is the root package `dbsql` (`connection.go`, `connector.go`,
 `driver.go`, `statement.go`, `result.go`, `parameters.go`, …) plus subpackages
 `auth/`, `rows/`, `errors/`, `logger/`, `driverctx/`, `telemetry/`, and
 `internal/` (client, Thrift protocol, fetcher, etc.). Public API stability

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       - name: Build + warm caches (pure-Go; while JFrog creds are present)

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       - name: Build driver + warm caches (pure-Go; while JFrog creds are present)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,16 +33,16 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       - name: Lint
         uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
-          # v2.x is built with go 1.25+, which is required so the
-          # linter can read Go 1.25 stdlib export data. The v1 family
+          # v2.x is built with a current Go toolchain, which is required so the
+          # linter can read Go 1.26 stdlib export data. The v1 family
           # was built with go ≤1.23 and produces "could not import
-          # sync/atomic" typecheck errors against our `go 1.25.0`
+          # sync/atomic" typecheck errors against our `go 1.26.0`
           # directive.
           version: 'v2.12'
   build-and-test:
@@ -50,11 +50,11 @@ jobs:
     strategy:
       # Matches Go's release support window. Per go.dev/doc/devel/release,
       # only the latest two major releases receive security patches.
-      # As of 2026-05 that's 1.25 (Active LTS) and 1.26. The protected
-      # runners pin GOTOOLCHAIN=local so we can't include 1.24 — Go would
-      # refuse to satisfy the `go 1.25.0` directive without auto-downloading.
+      # As of 2026-09 that's 1.26 and 1.27. The protected runners pin
+      # GOTOOLCHAIN=local, so older versions cannot satisfy the `go 1.26.0`
+      # directive without auto-downloading.
       matrix:
-        go-version: ['1.25.x', '1.26.x']
+        go-version: ['1.26.x', '1.27.x']
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       # Install the exact toolchain the kernel .a is built with. rust-toolchain.toml

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       - name: Get dependencies
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: false
 
       # Keep in lockstep with rust-toolchain.toml's channel (it governs the archive

--- a/.github/workflows/securityScan.yml
+++ b/.github/workflows/securityScan.yml
@@ -56,13 +56,13 @@ jobs:
       - name: Set up Go Toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Must be >= the go.mod directive (1.25.0). A floating '1.25.x'
-          # resolves to the runner's cached latest 1.25 patch, which always
-          # satisfies the 1.25.0 floor. osv-scanner shells out to
+          # Must be >= the go.mod directive (1.26.0). A floating '1.26.x'
+          # resolves to the runner's cached latest 1.26 patch, which always
+          # satisfies the 1.26.0 floor. osv-scanner shells out to
           # govulncheck, which loads the module with this toolchain; keeping
-          # the directive at the honest 1.25.0 floor (not an inflated patch)
-          # means '1.25.x' never falls below it.
-          go-version: '1.25.x'
+          # the directive at the honest 1.26.0 floor (not an inflated patch)
+          # means '1.26.x' never falls below it.
+          go-version: '1.26.x'
           cache: false
 
       - name: Install osv-scanner
@@ -153,7 +153,7 @@ jobs:
           #     slip the gate.
           #   - stdlib UNKNOWN        -> report-only (NON-blocking). These are
           #     Go stdlib advisories flagged against the go.mod directive
-          #     floor (e.g. `go 1.25.0`); they are delivered to consumers via
+          #     floor (e.g. `go 1.26.0`); they are delivered to consumers via
           #     GOTOOLCHAIN patch auto-download and are not a real exposure of
           #     the module itself. Inflating the directive to the latest patch
           #     purely to silence them would tighten the customer floor for no

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/databricks/databricks-sql-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/apache/arrow/go/v12 v12.0.1
-	github.com/apache/thrift v0.23.0
+	github.com/apache/thrift v0.24.0
 	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.4.0
@@ -36,7 +36,7 @@ require (
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apache/arrow/go/v12 v12.0.1 h1:JsR2+hzYYjgSUkBSaahpqCetqZMr76djX80fF/DiJbg=
 github.com/apache/arrow/go/v12 v12.0.1/go.mod h1:weuTY7JvTG/HDPtMQxEUp7pU73vkLWMLpY67QwZ/WWw=
-github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
-github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
+github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/coreos/go-oidc/v3 v3.5.0 h1:VxKtbccHZxs8juq7RdJntSqtXFtde9YpNpGn0yqgEHw=
 github.com/coreos/go-oidc/v3 v3.5.0/go.mod h1:ecXRtV4romGPeO6ieExAsUK9cb/3fp9hXNz1tlv8PIM=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
@@ -130,8 +130,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
## Summary

- Upgrade Apache Thrift from 0.23.0 to 0.24.0.
- Upgrade `golang.org/x/crypto` from 0.55.0 to 0.56.0.
- Raise the Go directive to 1.26 and align CI/tooling references with the Go 1.26 requirement.
- Test supported Go releases 1.26 and 1.27 in CI.

These updates address the blocking dependency findings from the repository security scan.

## Testing

- `go test ./...` with Go 1.26
- Resolved module versions verified with `go list -m`
- `git diff --check`